### PR TITLE
feat: playlist 페이지 간 이동 기능 구현

### DIFF
--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -106,8 +106,13 @@ public class QuestionFindController {
     @GetMapping("/play")
     @PreAuthorize("isAuthenticated()")
     public String play(Model model) {
+        log.info("문제 리스트 실행 요청 확인");
+
         List<Long> playlist = (List<Long>) rq.getSession().getAttribute("playlist");
-        log.info("문제 리스트 실행 요청 확인 playlist size = {}", playlist.size());
+        if (playlist == null){
+            log.info("플레이 리스트가 없습니다.");
+            return rq.redirectWithMsg("/question/function", "문제 설정을 먼저 해주세요.");
+        }
 
         List<Question> questions = questionService.findByIdList(playlist);
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -17,6 +17,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -105,8 +106,11 @@ public class QuestionFindController {
     //-- 랜덤 문제 실행 --//
     @GetMapping("/play")
     @PreAuthorize("isAuthenticated()")
-    public String play(Model model) {
-        log.info("문제 리스트 실행 요청 확인");
+    public String play(
+            @RequestParam(defaultValue = "0") int page,
+            Model model
+    ) {
+        log.info("문제 리스트 실행 요청 확인 page = {}", page);
 
         List<Long> playlist = (List<Long>) rq.getSession().getAttribute("playlist");
         if (playlist == null){
@@ -116,10 +120,12 @@ public class QuestionFindController {
 
         List<Question> questions = questionService.findByIdList(playlist);
 
-        model.addAttribute("questions", questions);
+        model.addAttribute("question", questions.get(page));
+        model.addAttribute("size", questions.size() - 1);
+        model.addAttribute("page", page);
         model.addAttribute("mcq", MCQ);
 
-        log.info("문제 리스트 실행");
+        log.info("문제 리스트 실행 id = {}", questions.get(page).getId());
         return "usr/question/top/play";
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
@@ -22,24 +22,6 @@ public class QuestionQueryRepository {
     }
 
 
-    //-- play list 생성 (지연로딩으로 인해서 세션에 저장할 수 없음)
-    public List<Question> play(List<Long> id, List<QuestionType> type, List<Integer> difficulties, Integer count) {
-
-
-        List<Question> questions = query.selectFrom(question)
-                .where(question.category.id.in(id)
-                        .and(question.type.in(type))
-                        .and(question.difficulty.in(difficulties)))
-                .fetch();
-
-        // 랜덤한 순서로 정렬하기 위해 랜덤 값을 생성하여 정렬에 활용
-        long seed = System.nanoTime();
-        Collections.shuffle(questions, new Random(seed));
-
-        // count 만큼 잘라내기
-        return questions.subList(0, Math.min(count, questions.size()));
-    }
-
     //-- play list id 로만 조회 --//
     public List<Long> playlist(List<Long> id, List<QuestionType> type, List<Integer> difficulties, Integer count) {
 
@@ -58,7 +40,7 @@ public class QuestionQueryRepository {
         return questionIds.subList(0, Math.min(count, questionIds.size()));
     }
 
-    //-- find by id --//
+    //-- find by id list --//
     public List<Question> findById(List<Long> id) {
         return query
                 .selectFrom(question)

--- a/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
@@ -9,7 +9,10 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Repository
 public class QuestionQueryRepository {
@@ -40,14 +43,22 @@ public class QuestionQueryRepository {
         return questionIds.subList(0, Math.min(count, questionIds.size()));
     }
 
-    //-- find by id list --//
+    //-- find by id --//
     public List<Question> findById(List<Long> id) {
-        return query
+        List<Question> questions = query
                 .selectFrom(question)
                 .where(question.id.in(id))
                 .fetch();
+
+        // 조화한 list 를 id 를 key 값으로 하는 map 으로 변환
+        Map<Long, Question> sorter = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        // id 의 인덱스를 key 로 value 를 담는 list 를 반환
+        return id.stream()
+                .map(sorter::get)
+                .collect(Collectors.toList());
     }
 }
-
 
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/service/QuestionService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/service/QuestionService.java
@@ -17,12 +17,10 @@ import com.twenty.inhub.boundedContext.question.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.twenty.inhub.boundedContext.question.entity.QuestionType.MCQ;
 import static com.twenty.inhub.boundedContext.question.entity.QuestionType.SAQ;

--- a/src/main/resources/templates/usr/question/fragment/create/form.html
+++ b/src/main/resources/templates/usr/question/fragment/create/form.html
@@ -40,7 +40,7 @@
            th:field="*{name}"
            placeholder="제목"/>
 
-    <textarea class="textarea textarea-bordered"
+    <textarea class="textarea textarea-bordered h-40"
               th:field="*{content}"
               placeholder="문제"></textarea>
 

--- a/src/main/resources/templates/usr/question/fragment/play/content.html
+++ b/src/main/resources/templates/usr/question/fragment/play/content.html
@@ -8,7 +8,10 @@
          class="form-control">
         <label class="label cursor-pointer">
             <span class="label-text" th:text="|${roop.count}.  ${choice.choice}|"></span>
-            <input type="radio" name="radio-10" class="radio checked:bg-red-500" checked disabled/>
+            <input type="radio" name="radio-10" class="radio checked:bg-red-500" checked/>
         </label>
     </div>
+
+    <textarea th:if="${question.type ne mcq}"
+              class="textarea textarea-bordered w-full h-40 mt-3" placeholder="답변 입력"></textarea>
 </div>

--- a/src/main/resources/templates/usr/question/fragment/play/nav.html
+++ b/src/main/resources/templates/usr/question/fragment/play/nav.html
@@ -1,17 +1,20 @@
-<div th:fragment="nav(question)"
-     class="mb-12 flex flex-col pt-5 border-t-[1px] mb-8 ">
+<div th:fragment="nav(question, page, size)"
+     class="mb-12 flex flex-col justify-end pt-5 border-t-[1px] mb-8 ">
 
 
   <div class="flex justify-center gap-5">
 
-    <a href="#">
+    <a th:if="${page > 0}"
+       th:href="@{|?page=${page - 1}|}">
       <i class="fa-solid fa-chevron-left"></i></a>
 
     <a><i class="fa-solid fa-highlighter"></i></a>
 
     <a><i class="fa-regular fa-comment"></i></a>
 
-    <a><i class="fa-solid fa-chevron-right"></i></a>
+    <a th:if="${page < size}"
+       th:href="@{|?page=${page + 1}|}">
+      <i class="fa-solid fa-chevron-right"></i></a>
   </div>
 
 </div>

--- a/src/main/resources/templates/usr/question/fragment/play/stack.html
+++ b/src/main/resources/templates/usr/question/fragment/play/stack.html
@@ -1,15 +1,16 @@
-<div th:fragment="stack(questions, mcq)"
+<div th:fragment="stack(question, mcq, page, size)"
      class="min-h-full mt-5 mb-12">
 
     <div class="stack">
 
-        <div th:each="question, roop : ${questions}"
-             th:object="${question}"
-             class="text-center border border-base-content card w-36 min-h-full bg-base-100">
+        <div class="text-center border border-base-content card w-36 min-h-full bg-base-100">
 
             <div th:replace="~{usr/question/fragment/play/card :: card(${question}, ${mcq})}"></div>
-            <div th:replace="~{usr/question/fragment/play/nav :: nav(${question})}"></div>
+            <div th:replace="~{usr/question/fragment/play/nav :: nav(${question}, ${page}, ${size})}"></div>
         </div>
+
+        <div class="text-center border border-base-content card w-36 min-h-full bg-base-100"></div>
+        <div class="text-center border border-base-content card w-36 min-h-full bg-base-100"></div>
 
     </div>
 </div>

--- a/src/main/resources/templates/usr/question/top/play.html
+++ b/src/main/resources/templates/usr/question/top/play.html
@@ -4,7 +4,10 @@
 
 <div layout:fragment="content" class="min-h-screen flex flex-col items-center pb-12 bg-base-200">
 
-  <div th:replace="~{usr/question/fragment/play/stack :: stack(${questions}, ${mcq})}"></div>
-  <div class="mb-12 pb-12"/>
+    <div th:replace="~{usr/question/fragment/play/stack :: stack(${question}, ${mcq}, ${page}, ${size})}"></div>
+
+    <progress class="progress progress-primary-content w-56 mt-3" th:value="${page}" th:max="${size}"></progress>
+
+    <div class="mb-12 pb-12"/>
 </div>
 </html>


### PR DESCRIPTION
### 업데이트 내용

- 랜덤문제 설정을 하지 않고 문제 실행 페이지로 건너 뛰어서 온 클라이언트를 설정 페이지로 돌려보내는 로직 추가
- 처음에 구현한 List<Question> 을 반환하는 query dsl 코드 삭제
    - List<Long> 을 반환하고 그 값으로 List 를 조회하는 방식으로 변경했음
- playlist 페이지 간 이동 기능 구현
    - 현재 페이지를 표시하는 바 추가