### PR TITLE
refactor: 각 API 마다 속성들을 관리하는 클래스 생성

### DIFF
--- a/src/main/java/com/twenty/inhub/base/security/OAuthAttributes.java
+++ b/src/main/java/com/twenty/inhub/base/security/OAuthAttributes.java
@@ -1,0 +1,72 @@
+package com.twenty.inhub.base.security;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@ToString
+public class OAuthAttributes {
+
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
+        // 여기서 깃허브와 카카오, 구글 구분 (ofGitHub, ofKakao)
+        if("GITHUB".equals(registrationId)) {
+            return ofGitHub(userNameAttributeName, attributes);
+        }
+
+        if("KAKAO".equals(registrationId)) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+//                .name((String) attributes.get("name"))
+//                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+//                .attributes(attributes)
+//                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        // kakao는 kakao_account에 유저정보가 있다. (email)
+        Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+        // kakao_account안에 또 profile이라는 JSON객체가 있다. (nickname, profile_image)
+        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
+
+        return OAuthAttributes.builder()
+//                .name((String) kakaoProfile.get("nickname"))
+//                .email((String) kakaoAccount.get("email"))
+                .picture((String) kakaoProfile.get("profile_image_url"))
+//                .attributes(attributes)
+//                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofGitHub(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .picture((String) attributes.get("avatar_url"))
+                .build();
+    }
+
+}


### PR DESCRIPTION
# 프로필 사진 가져오기 리팩토링

- loadUser 메소드가 너무 커지고 난잡해서 OAuthAttributes 클래스를 따로 만들어서 관리 해야 함

결과

- OAuthAttributes 클래스 생성
    - attributes : 모든 속성 값들을 map 형태로 가지고 있는 필드
    - 그 외 : attributes에서 이름(키)에 맞는 속성 값을 저장하는 필드
- CustomOAuth2UserService.loadUser() 메소드가 굉장히 간단 명료해졌고, 나중에 원하는 속성 값을 추가/삭제 할 때도 쉽게 가능함