### PR TITLE
feat: 밑줄 문제 풀기 / CRUD 구현, test 완료

### DIFF
--- a/src/main/java/com/twenty/inhub/boundedContext/category/CategoryQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/category/CategoryQueryRepository.java
@@ -1,0 +1,41 @@
+package com.twenty.inhub.boundedContext.category;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.member.entity.QMember;
+import com.twenty.inhub.boundedContext.question.entity.QQuestion;
+import com.twenty.inhub.boundedContext.question.entity.Question;
+import com.twenty.inhub.boundedContext.underline.QUnderline;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class CategoryQueryRepository {
+
+    private final JPAQueryFactory query;
+    private QCategory category = QCategory.category;
+    private QQuestion question = QQuestion.question;
+    private QMember member = QMember.member;
+    private QUnderline underline = QUnderline.underline;
+
+    public CategoryQueryRepository(EntityManager em) {
+        this.query = new JPAQueryFactory(em);
+    }
+
+    //-- underline 에 포함된 카테고리만 조회하기 --//
+    public List<Category> findContainUnderline(Member member, List<Question> questions) {
+        return query
+                .selectFrom(category)
+                .join(question).on(category.eq(question.category))
+                .join(underline).on(question.eq(underline.question))
+                .join(this.member).on(underline.member.eq(member))
+                .where(underline.question.in(questions))
+                .fetch();
+    }
+
+
+
+
+}

--- a/src/main/java/com/twenty/inhub/boundedContext/category/CategoryService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/category/CategoryService.java
@@ -2,6 +2,8 @@ package com.twenty.inhub.boundedContext.category;
 
 import com.twenty.inhub.base.request.RsData;
 import com.twenty.inhub.boundedContext.category.form.CreateCategoryForm;
+import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.question.entity.Question;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import java.util.Optional;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final CategoryQueryRepository categoryQueryRepository;
 
     /**
      * ** CREATE METHOD **
@@ -40,6 +43,7 @@ public class CategoryService {
      * find by name
      * find all
      * find by id
+     * find contain underline
      */
 
     //-- find by name --//
@@ -65,5 +69,10 @@ public class CategoryService {
             return RsData.of(byId.get());
 
         return RsData.of("F-1", "존재하지 않는 id");
+    }
+
+    //-- find contain underline --//
+    public List<Category> findContainUnderline(Member member, List<Question> questions) {
+        return categoryQueryRepository.findContainUnderline(member, questions);
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -12,6 +12,7 @@ import com.twenty.inhub.boundedContext.question.controller.form.QuestionSearchFo
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.entity.QuestionType;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
+import com.twenty.inhub.boundedContext.underline.Underline;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -65,6 +66,11 @@ public class QuestionFindController {
     @GetMapping("/search")
     public String search(QuestionSearchForm form, Model model) {
         log.info("문제 검색 요청 확인 input = {}", form.getTag());
+
+        if (form.getSelect() == 1) {
+            List<Underline> underlines = rq.getMember().getUnderlines();
+            form.setUnderlines(underlines);
+        }
 
         List<Question> questions = questionService.findByInput(form);
         model.addAttribute("questions", questions);

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.twenty.inhub.boundedContext.member.entity.MemberRole.ADMIN;
@@ -153,10 +154,12 @@ public class QuestionFindController {
             return rq.redirectWithMsg("/answer/list", "문제 제출 완료");
         }
 
-        RsData<Answer> answerRs = questionService.findAnswerByQustionMember(questions.get(page), rq.getMember());
+        List<Answer> answerList = (List<Answer>) rq.getSession().getAttribute("answerList");
 
-        if (answerRs.isSuccess())
-            form.setContent(answerRs.getData().getContent());
+        if (answerList == null)
+            answerList = new ArrayList<>();
+        else if (answerList.size() > page)
+            form.setContent(answerList.get(page).getContent());
 
         model.addAttribute("question", questions.get(page));
         model.addAttribute("size", questions.size() - 1);

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -126,6 +126,9 @@ public class QuestionFindController {
         List<Long> playlist = questionService.getPlaylist(form);
         rq.getSession().setAttribute("playlist", playlist);
 
+        List<Answer> answerList = (List<Answer>) rq.getSession().getAttribute("answerList");
+        if (answerList != null) answerList.clear();
+
         model.addAttribute("mcq", MCQ);
 
         log.info("랜덤 문제 응답 완료 question count = {}", playlist.size());

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/form/CreateFunctionForm.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/form/CreateFunctionForm.java
@@ -1,6 +1,7 @@
 package com.twenty.inhub.boundedContext.question.controller.form;
 
 import com.twenty.inhub.boundedContext.question.entity.QuestionType;
+import com.twenty.inhub.boundedContext.underline.Underline;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -13,6 +14,6 @@ public class CreateFunctionForm {
     private List<Long> categories;
     private List<QuestionType> type;
     private List<Integer> difficulties;
+    private List<Underline> underlines;
     private Integer count;
-
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/form/QuestionSearchForm.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/form/QuestionSearchForm.java
@@ -1,12 +1,17 @@
 package com.twenty.inhub.boundedContext.question.controller.form;
 
+import com.twenty.inhub.boundedContext.underline.Underline;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 public class QuestionSearchForm {
 
     private String tag;
+    private int select;
+    private List<Underline> underlines;
 
     public QuestionSearchForm(String tag) {
         this.tag = tag;

--- a/src/main/java/com/twenty/inhub/boundedContext/question/entity/Question.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/entity/Question.java
@@ -180,7 +180,6 @@ public class Question extends BaseEntity {
     public void deleteQuestion() {
         this.category.getQuestions().remove(this);
         this.member.getQuestions().remove(this);
-//        this.underlines
         this.category = null;
         this.member = null;
     }

--- a/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
@@ -92,11 +92,13 @@ public class QuestionQueryRepository {
 
         BooleanBuilder builder = new BooleanBuilder();
         String tag = form.getTag();
-//        Long id = form.getCategoryId();
+        List<Underline> underlines = form.getUnderlines();
 
         if (StringUtils.hasText(tag))
             builder.and(question.tags.any().tag.like("%" + tag + "%"));
 
+        if (underlines != null)
+            builder.and(question.underlines.any().in(underlines));
 
         return query
                 .selectFrom(question)

--- a/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
@@ -99,7 +99,7 @@ public class QuestionQueryRepository {
                 .fetch();
     }
 
-    //-- find by category , underline --//
+    //-- underline 의 특정 category 에 포함된 question 만 조회 --//
     public List<Question> findByCategoryUnderline(Category category, List<Underline> underlines) {
         return query
                 .selectFrom(question)
@@ -107,7 +107,6 @@ public class QuestionQueryRepository {
                         .and(question.underlines.any().in(underlines)))
                 .fetch();
     }
-
 }
 
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
@@ -1,6 +1,7 @@
 package com.twenty.inhub.boundedContext.question.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.twenty.inhub.boundedContext.answer.entity.Answer;
 import com.twenty.inhub.boundedContext.answer.entity.QAnswer;
@@ -37,14 +38,19 @@ public class QuestionQueryRepository {
 
 
     //-- play list id 로만 조회 --//
-    public List<Long> playlist(List<Long> id, List<QuestionType> type, List<Integer> difficulties, Integer count) {
+    public List<Long> playlist(List<Long> id, List<QuestionType> type, List<Integer> difficulties, Integer count, List<Underline> underlines) {
 
-        List<Long> questionIds = query.select(question.id)
+        JPAQuery<Long> query = this.query.select(question.id)
                 .from(question)
                 .where(question.category.id.in(id)
                         .and(question.type.in(type))
-                        .and(question.difficulty.in(difficulties)))
-                .fetch();
+                        .and(question.difficulty.in(difficulties)));
+
+        // 동적 쿼리
+        if (underlines != null)
+            query = query.where(question.underlines.any().in(underlines));
+
+        List<Long> questionIds = query.fetch();
 
         // 랜덤한 순서로 정렬하기 위해 랜덤 값을 생성하여 정렬에 활용
         long seed = System.nanoTime();

--- a/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/repository/QuestionQueryRepository.java
@@ -4,12 +4,14 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.twenty.inhub.boundedContext.answer.entity.Answer;
 import com.twenty.inhub.boundedContext.answer.entity.QAnswer;
+import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.QCategory;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.question.controller.form.QuestionSearchForm;
 import com.twenty.inhub.boundedContext.question.entity.QQuestion;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.entity.QuestionType;
+import com.twenty.inhub.boundedContext.underline.Underline;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -94,6 +96,15 @@ public class QuestionQueryRepository {
                 .selectFrom(question)
                 .leftJoin(question.tags)
                 .where(builder)
+                .fetch();
+    }
+
+    //-- find by category , underline --//
+    public List<Question> findByCategoryUnderline(Category category, List<Underline> underlines) {
+        return query
+                .selectFrom(question)
+                .where(question.category.eq(category)
+                        .and(question.underlines.any().in(underlines)))
                 .fetch();
     }
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/service/QuestionService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/service/QuestionService.java
@@ -144,7 +144,8 @@ public class QuestionService {
                 form.getCategories(),
                 form.getType(),
                 form.getDifficulties(),
-                form.getCount()
+                form.getCount(),
+                form.getUnderlines()
         );
     }
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/service/QuestionService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/service/QuestionService.java
@@ -125,6 +125,7 @@ public class QuestionService {
      * find by id list
      * find by input
      * find all
+     * find by category , underlines
      */
 
     //-- find by id --//
@@ -165,6 +166,12 @@ public class QuestionService {
     public List<Question> findAll() {
         return questionRepository.findAll();
     }
+
+    //-- find by category , underlines --//
+    public List<Question> findByCategoryUnderline(Category category, List<Underline> underlines) {
+        return questionQueryRepository.findByCategoryUnderline(category, underlines);
+    }
+
 
 
     /**

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/Underline.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/Underline.java
@@ -43,10 +43,18 @@ public class Underline extends BaseEntity {
         return build;
     }
 
+    //-- business method --//
+
+    // delete //
     protected void delete() {
         this.member.getUnderlines().remove(this);
         this.question.getUnderlines().remove(this);
         this.member = null;
         this.question = null;
+    }
+
+    // update about //
+    public void updateAbout(String about) {
+        this.about = about;
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -206,4 +206,22 @@ public class UnderlineController {
         log.info("문제 설정폼 응답 완료");
         return "usr/underline/top/function";
     }
+
+    //-- 랜덤 문제 리스트 생성 --//
+    @GetMapping("/playlist")
+    @PreAuthorize("isAuthenticated()")
+    public String playlist(CreateFunctionForm form, Model model) {
+        log.info("밑줄 문제 리스트 생성 요청 확인 question count = {}", form.getCount());
+
+        List<Underline> underlines = rq.getMember().getUnderlines();
+        form.setUnderlines(underlines);
+
+        List<Long> playlist = questionService.getPlaylist(form);
+        rq.getSession().setAttribute("playlist", playlist);
+
+        model.addAttribute("mcq", MCQ);
+
+        log.info("랜덤 문제 응답 완료 question count = {}", playlist.size());
+        return "usr/question/top/playlist";
+    }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -2,17 +2,27 @@ package com.twenty.inhub.boundedContext.underline;
 
 import com.twenty.inhub.base.request.Rq;
 import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.category.Category;
+import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.member.repository.MemberRepository;
+import com.twenty.inhub.boundedContext.member.service.MemberService;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Controller
@@ -21,8 +31,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UnderlineController {
 
     private final UnderlineService underlineService;
-    private final MemberRepository memberService; // 임시로 Member Repository 메서드 사용함
+    private final MemberService memberService;
     private final QuestionService questionService;
+    private final CategoryService categoryService;
     private final Rq rq;
 
 
@@ -37,7 +48,7 @@ public class UnderlineController {
     ) {
         log.info("밑줄 긋기 생성 요청 확인 question id = {}", questionId);
 
-        Member member = memberService.findById(memberId).get();// 임시로 repository 메서드 사용함
+        Member member = memberService.findById(memberId).get();
         RsData<Question> questionRs = questionService.findById(questionId);
 
         if (questionRs.isFail()) {
@@ -59,7 +70,45 @@ public class UnderlineController {
 
         else
             return rq.redirectWithMsg("/question/play?page=" + page, underlineRs.getMsg());
+    }
 
+    //-- 밑줄 문제 카테고리 목록 --//
+    @GetMapping("/category")
+    @PreAuthorize("isAuthenticated()")
+    public String categoryList(Model model) {
+        log.info("밑줄 문제 카테고리 목록 요청 확인");
 
+        List<Underline> underlines = rq.getMember().getUnderlines();
+        Set<Category> categories = new HashSet<>();
+        for (Underline underline : underlines)
+            categories.add(underline.getQuestion().getCategory());
+
+        model.addAttribute("categories", categories);
+
+        log.info("밑줄 문제 카테고리 목록 응답 완료 count = {}", underlines.size());
+        return "usr/underline/top/category";
+    }
+
+    //-- 밑줄 문제 목로 --//
+    @GetMapping("/list/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public String list(
+            @PathVariable Long id,
+            Model model
+    ) {
+        log.info("밑줄 문제 목록 요청 확인 category id = {}", id);
+
+        RsData<Category> categoryRs = categoryService.findById(id);
+
+        if (categoryRs.isFail()) {
+            log.info("조회 실패 msg = {}", categoryRs.getMsg());
+            return rq.historyBack(categoryRs.getMsg());
+        }
+
+        List<Underline> underlines = underlineService.findByCategory(rq.getMember(), categoryRs.getData());
+        model.addAttribute("underlines", underlines);
+
+        log.info("밑줄 문제 목록 응답 완료 category id = {} / count = {}", id, underlines.size());
+        return "usr/underline/top/list";
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -5,7 +5,6 @@ import com.twenty.inhub.base.request.RsData;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
-import com.twenty.inhub.boundedContext.member.repository.MemberRepository;
 import com.twenty.inhub.boundedContext.member.service.MemberService;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
@@ -19,10 +18,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static com.twenty.inhub.boundedContext.question.entity.QuestionType.MCQ;
 
 @Slf4j
 @Controller
@@ -99,16 +99,23 @@ public class UnderlineController {
         log.info("밑줄 문제 목록 요청 확인 category id = {}", id);
 
         RsData<Category> categoryRs = categoryService.findById(id);
+        Member member = rq.getMember();
 
         if (categoryRs.isFail()) {
             log.info("조회 실패 msg = {}", categoryRs.getMsg());
             return rq.historyBack(categoryRs.getMsg());
         }
 
-        List<Underline> underlines = underlineService.findByCategory(rq.getMember(), categoryRs.getData());
-        model.addAttribute("underlines", underlines);
+        List<Question> questions = questionService
+                .findByCategoryUnderline(categoryRs.getData(), member.getUnderlines());
 
-        log.info("밑줄 문제 목록 응답 완료 category id = {} / count = {}", id, underlines.size());
+        Question question = questionService.findById(1L).getData();
+        String name = question.getName();
+
+        model.addAttribute("questions", questions);
+        model.addAttribute("mcq", MCQ);
+
+        log.info("밑줄 문제 목록 응답 완료 category id = {} / count = {}", id, questions.size());
         return "usr/underline/top/list";
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -8,6 +8,7 @@ import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.question.controller.form.CreateFunctionForm;
+import com.twenty.inhub.boundedContext.question.controller.form.QuestionSearchForm;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.entity.QuestionType;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.twenty.inhub.boundedContext.member.entity.MemberRole.ADMIN;
 import static com.twenty.inhub.boundedContext.question.entity.QuestionType.MCQ;
 
 @Slf4j
@@ -74,7 +76,10 @@ public class UnderlineController {
 
     //-- 밑줄 문제 카테고리 목록 --//
     @GetMapping("/category")
-    public String categoryList(Model model) {
+    public String categoryList(
+            QuestionSearchForm form,
+            Model model
+    ) {
         log.info("밑줄 문제 카테고리 목록 요청 확인");
 
         // underline 의 카테고리별 count 를 어떻게하면 효율적으로 조회할 수 있을까?
@@ -84,6 +89,7 @@ public class UnderlineController {
                 .collect(Collectors.toList());
         List<Category> categories = categoryService.findContainUnderline(member, questions);
 
+        form.setSelect(1);
         model.addAttribute("categories", categories);
 
         log.info("밑줄 문제 카테고리 목록 응답 완료 count = {}", categories.size());
@@ -93,6 +99,7 @@ public class UnderlineController {
     //-- 밑줄 문제 목록 --//
     @GetMapping("/list/{id}")
     public String list(
+            QuestionSearchForm form,
             @PathVariable Long id,
             Model model
     ) {
@@ -110,6 +117,7 @@ public class UnderlineController {
         List<Question> questions = questionService
                 .findByCategoryUnderline(category, member.getUnderlines());
 
+        form.setSelect(1);
         model.addAttribute("category", category);
         model.addAttribute("questions", questions);
         model.addAttribute("mcq", MCQ);

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -6,7 +6,9 @@ import com.twenty.inhub.boundedContext.answer.entity.AnswerCheck;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.question.controller.form.CreateFunctionForm;
 import com.twenty.inhub.boundedContext.question.entity.Question;
+import com.twenty.inhub.boundedContext.question.entity.QuestionType;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -179,5 +181,29 @@ public class UnderlineController {
 
         log.info("밑줄 삭제 완료");
         return rq.redirectWithMsg("/underline/list/" + categoryId, "삭제가 완료되었습니다.");
+    }
+
+    //-- 밑줄 문제 풀기 설정폼 --//
+    @GetMapping("/function")
+    @PreAuthorize("isAuthenticated()")
+    public String function(CreateFunctionForm form, Model model) {
+        log.info("밑줄 문제 풀기 설정폼 요청 확인");
+
+        Member member = rq.getMember();
+        List<Question> questions = member.getUnderlines().stream()
+                .map(Underline::getQuestion)
+                .collect(Collectors.toList());
+
+        List<Category> categories = categoryService.findContainUnderline(member, questions);
+        List<QuestionType> types = questionService.findQuestionType();
+        List<Integer> difficulties = questionService.findDifficultyList();
+
+        model.addAttribute("difficulties", difficulties);
+        model.addAttribute("categories", categories);
+        model.addAttribute("types", types);
+        model.addAttribute("mcq", MCQ);
+
+        log.info("문제 설정폼 응답 완료");
+        return "usr/underline/top/function";
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -105,13 +105,12 @@ public class UnderlineController {
             log.info("조회 실패 msg = {}", categoryRs.getMsg());
             return rq.historyBack(categoryRs.getMsg());
         }
+        Category category = categoryRs.getData();
 
         List<Question> questions = questionService
-                .findByCategoryUnderline(categoryRs.getData(), member.getUnderlines());
+                .findByCategoryUnderline(category, member.getUnderlines());
 
-        Question question = questionService.findById(1L).getData();
-        String name = question.getName();
-
+        model.addAttribute("category", category);
         model.addAttribute("questions", questions);
         model.addAttribute("mcq", MCQ);
 

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -2,6 +2,7 @@ package com.twenty.inhub.boundedContext.underline;
 
 import com.twenty.inhub.base.request.Rq;
 import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.answer.entity.Answer;
 import com.twenty.inhub.boundedContext.answer.entity.AnswerCheck;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
@@ -218,6 +219,9 @@ public class UnderlineController {
 
         List<Long> playlist = questionService.getPlaylist(form);
         rq.getSession().setAttribute("playlist", playlist);
+
+        List<Answer> answerList = (List<Answer>) rq.getSession().getAttribute("answerList");
+        if (answerList != null) answerList.clear();
 
         model.addAttribute("mcq", MCQ);
 

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -2,6 +2,7 @@ package com.twenty.inhub.boundedContext.underline;
 
 import com.twenty.inhub.base.request.Rq;
 import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.answer.entity.AnswerCheck;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
@@ -18,14 +19,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.twenty.inhub.boundedContext.question.entity.QuestionType.MCQ;
 
 @Slf4j
 @Controller
+@PreAuthorize("isAuthenticated()")
 @RequestMapping("/underline")
 @RequiredArgsConstructor
 public class UnderlineController {
@@ -38,17 +39,15 @@ public class UnderlineController {
 
 
     //-- 밑줄 긋기 생성 --//
-    @PostMapping("/create/{member}/{question}/{page}")
-    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/create/{question}/{page}")
     public String create(
             String about,
-            @PathVariable("member") Long memberId,
             @PathVariable("question") Long questionId,
             @PathVariable int page
     ) {
         log.info("밑줄 긋기 생성 요청 확인 question id = {}", questionId);
 
-        Member member = memberService.findById(memberId).get();
+        Member member = rq.getMember();
         RsData<Question> questionRs = questionService.findById(questionId);
 
         if (questionRs.isFail()) {
@@ -74,24 +73,24 @@ public class UnderlineController {
 
     //-- 밑줄 문제 카테고리 목록 --//
     @GetMapping("/category")
-    @PreAuthorize("isAuthenticated()")
     public String categoryList(Model model) {
         log.info("밑줄 문제 카테고리 목록 요청 확인");
 
-        List<Underline> underlines = rq.getMember().getUnderlines();
-        Set<Category> categories = new HashSet<>();
-        for (Underline underline : underlines)
-            categories.add(underline.getQuestion().getCategory());
+        // underline 의 카테고리별 count 를 어떻게하면 효율적으로 조회할 수 있을까?
+        Member member = rq.getMember();
+        List<Question> questions = member.getUnderlines().stream()
+                .map(Underline::getQuestion)
+                .collect(Collectors.toList());
+        List<Category> categories = categoryService.findContainUnderline(member, questions);
 
         model.addAttribute("categories", categories);
 
-        log.info("밑줄 문제 카테고리 목록 응답 완료 count = {}", underlines.size());
+        log.info("밑줄 문제 카테고리 목록 응답 완료 count = {}", categories.size());
         return "usr/underline/top/category";
     }
 
-    //-- 밑줄 문제 목로 --//
+    //-- 밑줄 문제 목록 --//
     @GetMapping("/list/{id}")
-    @PreAuthorize("isAuthenticated()")
     public String list(
             @PathVariable Long id,
             Model model
@@ -116,5 +115,34 @@ public class UnderlineController {
 
         log.info("밑줄 문제 목록 응답 완료 category id = {} / count = {}", id, questions.size());
         return "usr/underline/top/list";
+    }
+
+    //-- underline 문제 상세페이지 --//
+    @GetMapping("/detail/{id}")
+    public String detail(@PathVariable Long id, Model model) {
+        log.info("밑줄 문제 상세페이지 요청 확인 question id = {}", id);
+
+        RsData<Question> questionRs = questionService.findById(id);
+
+        if (questionRs.isFail()) {
+            log.info("조회 실패 msg = {}", questionRs.getMsg());
+            return rq.historyBack(questionRs.getMsg());
+        }
+        Question question = questionRs.getData();
+        AnswerCheck check = question.getAnswerCheck();
+
+        RsData<Underline> underlineRs = underlineService.findByMemberQuestion(rq.getMember(), question);
+        if (underlineRs.isFail()) {
+            log.info("밑줄 목록 조회 실패 msg = {}", underlineRs.getMsg());
+            return rq.historyBack(underlineRs.getMsg());
+        }
+
+        model.addAttribute("underline", underlineRs.getData());
+        model.addAttribute("question", question);
+        model.addAttribute("check", check);
+        model.addAttribute("mcq", MCQ);
+
+        log.info("문제 상세페이지 응답 완료 category id = {}", id);
+        return "usr/underline/top/detail";
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -6,7 +6,6 @@ import com.twenty.inhub.boundedContext.answer.entity.AnswerCheck;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
-import com.twenty.inhub.boundedContext.member.service.MemberService;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +31,6 @@ import static com.twenty.inhub.boundedContext.question.entity.QuestionType.MCQ;
 public class UnderlineController {
 
     private final UnderlineService underlineService;
-    private final MemberService memberService;
     private final QuestionService questionService;
     private final CategoryService categoryService;
     private final Rq rq;
@@ -144,5 +142,42 @@ public class UnderlineController {
 
         log.info("문제 상세페이지 응답 완료 category id = {}", id);
         return "usr/underline/top/detail";
+    }
+
+    //-- 오답 노트 수정 --//
+    @PostMapping("/update/{id}")
+    public String update(
+            @PathVariable Long id,
+            String about
+    ) {
+        log.info("오답 노트 수정 요청 확인 id = {}", id);
+        RsData<Underline> underlineRs = underlineService.findById(id);
+
+        if (underlineRs.isFail()) {
+            log.info("id 조회 실패 msg = {}", underlineRs.getMsg());
+            return rq.historyBack(underlineRs.getMsg());
+        }
+
+        RsData<Underline> updateRs = underlineService.update(underlineRs.getData(), about);
+
+        log.info("오답노트 수정 완료 id = {}", id);
+        return rq.redirectWithMsg("/underline/detail/" + underlineRs.getData().getQuestion().getId(), updateRs.getMsg());
+    }
+
+    //-- 밑줄 삭제 --//
+    @PostMapping("/delete/{id}")
+    public String delete(@PathVariable Long id) {
+        log.info("밑줄 삭제 요청 확인 id = {}", id);
+
+        RsData<Underline> underlineRs = underlineService.findById(id);
+        if (underlineRs.isFail()) {
+            log.info("id 조회 실패 msg = {}", underlineRs.getMsg());
+            return rq.historyBack(underlineRs.getMsg());
+        }
+        Long categoryId = underlineRs.getData().getQuestion().getCategory().getId();
+        underlineService.delete(underlineRs.getData());
+
+        log.info("밑줄 삭제 완료");
+        return rq.redirectWithMsg("/underline/list/" + categoryId, "삭제가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineQueryRepository.java
@@ -1,6 +1,7 @@
 package com.twenty.inhub.boundedContext.underline;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
@@ -25,6 +26,15 @@ public class UnderlineQueryRepository {
                 .selectFrom(underline)
                 .where(underline.member.id.eq(memberId)
                         .and(underline.question.id.eq(questionId)))
+                .fetch();
+    }
+
+    //-- find by member , question --//
+    public List<Underline> findByCategory(Member member, Category category) {
+        return query
+                .selectFrom(underline)
+                .where(underline.question.category.eq(category)
+                        .and(underline.member.eq(member)))
                 .fetch();
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
@@ -1,6 +1,7 @@
 package com.twenty.inhub.boundedContext.underline;
 
 import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +51,7 @@ public class UnderlineService {
         return RsData.of("F-1", "존재하지 않는 내용입니다.");
     }
 
-    //-- find by member id , question id --//
+    //-- find by member , question --//
     public RsData<Underline> findByMemberQuestion(Member member, Question question) {
         List<Underline> underlines = underlineQueryRepository.findByMemberQuestion(member.getId(), question.getId());
 
@@ -61,6 +62,11 @@ public class UnderlineService {
             return RsData.of("F-1", "저장된 밑줄이 없습니다.");
 
         return RsData.of("F-2", "밑줄이 2개 이상입니다.");
+    }
+
+    //-- find by member , category --//
+    public List<Underline> findByCategory(Member member, Category category) {
+        return underlineQueryRepository.findByCategory(member, category);
     }
 
     //-- delete --//

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
@@ -69,6 +69,23 @@ public class UnderlineService {
         return underlineQueryRepository.findByCategory(member, category);
     }
 
+    //-- find by id --//
+    public RsData<Underline> findById(Long id) {
+        Optional<Underline> byId = underlineRepository.findById(id);
+
+        if (byId.isPresent())
+            return RsData.of(byId.get());
+
+        return RsData.of("F-1", "존재하지 않는 id 입니다.");
+    }
+
+    //-- update about --//
+    @Transactional
+    public RsData<Underline> update(Underline underline, String about) {
+        underline.updateAbout(about);
+        return RsData.of("S-1", "오답노트 수정 완료", underline);
+    }
+
     //-- delete --//
     @Transactional
     public void delete(Underline underline) {

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/dto/UnderlineCategoryDto.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/dto/UnderlineCategoryDto.java
@@ -1,0 +1,10 @@
+package com.twenty.inhub.boundedContext.underline.dto;
+
+import lombok.Data;
+
+@Data
+public class UnderlineCategoryDto {
+
+    private Long id;
+    private String name;
+}

--- a/src/main/resources/templates/usr/category/fragment/list/search.html
+++ b/src/main/resources/templates/usr/category/fragment/list/search.html
@@ -6,6 +6,11 @@
     <div class="form-control">
         <label class="input-group input-group-sm">
 
+            <select class="select select-sm select-bordered"
+                    th:field="*{select}">
+                <option value="0">모든 문제</option>
+                <option th:if="${@rq.login}" value="1" th:checked="*{select eq 1}">밑줄 문제</option>
+            </select>
 
             <input type="text" th:field="*{tag}" placeholder="검색어 입력"
                    class="input input-bordered input-sm"/>
@@ -15,18 +20,6 @@
                 <i class="fa-solid fa-magnifying-glass"></i>
             </button>
 
-<!--            <label for="my-modal-3" class="mt-3 text-lg ml-3">-->
-<!--                <i class="fa-solid fa-gear"></i></label>-->
-<!--            -->
-<!--            <input type="checkbox" id="my-modal-3" class="modal-toggle"/>-->
-<!--            <div class="modal">-->
-<!--                <div class="modal-box relative">-->
-<!--                    <label for="my-modal-3" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>-->
-<!--                    <h3 class="text-lg font-bold">상세 검색</h3>-->
-
-<!--                    -->
-<!--                </div>-->
-<!--            </div>-->
 
         </label>
 

--- a/src/main/resources/templates/usr/question/fragment/detail/underline.html
+++ b/src/main/resources/templates/usr/question/fragment/detail/underline.html
@@ -10,7 +10,7 @@
 
         <h3 class="font-bold text-lg" th:text="${question.name}"></h3>
 
-        <form th:action="@{/underline/create/{member}/{question}/{page}(member = ${@rq.member.id}, question = ${question.id}, page = '1000')}"
+        <form th:action="@{/underline/create/{question}/{page}(question = ${question.id}, page = '1000')}"
               method="post" class="mt-5 mb-5 flex flex-col">
 
           <textarea name="about" placeholder="오답노트"

--- a/src/main/resources/templates/usr/question/fragment/play/underline.html
+++ b/src/main/resources/templates/usr/question/fragment/play/underline.html
@@ -8,7 +8,7 @@
 
         <h3 class="font-bold text-lg" th:text="${question.name}"></h3>
 
-        <form th:action="@{/underline/create/{member}/{question}/{page}(member = ${@rq.member.id}, question = ${question.id}, page = ${page})}"
+        <form th:action="@{/underline/create/{question}/{page}(question = ${question.id}, page = ${page})}"
               method="post" class="mt-5 mb-5 flex flex-col">
 
           <textarea name="about" placeholder="오답노트"

--- a/src/main/resources/templates/usr/question/top/search.html
+++ b/src/main/resources/templates/usr/question/top/search.html
@@ -2,7 +2,7 @@
 
 <head><title>문제 목록</title></head>
 
-<div layout:fragment="content" class="min-h-screen flex flex-col">
+<div layout:fragment="content" class="min-h-screen flex flex-col mb-12">
 
     <div class="flex flex-col items-center gap-3">
         <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>
@@ -11,10 +11,24 @@
 
     <table th:replace="~{usr/question/fragment/search/table :: table(${questions}, ${mcq})}"></table>
 
-    <div th:if="${@rq.login}"
-         class="flex justify-end">
-        <a th:if="${@rq.member.role eq role}"
-           th:href="@{/question/create/{id}(id='-1')}"><i class="fa-regular fa-pen-to-square mr-5"></i></a>
+    <div class="flex justify-end gap-3 mt-3 mb-12">
+
+        <a th:if="${questionSearchForm.select eq 0}"
+           href="/category/list">
+            <i class="fa-solid fa-list-ul"></i>
+        </a>
+
+        <a th:if="${@rq.login and questionSearchForm.select eq 1}"
+           href="/underline/category">
+            <i class="fa-solid fa-list-ul"></i>
+        </a>
+
+        <a th:if="${@rq.login}"
+           th:href="@{/question/create/{id}(id='-1')}">
+            <i th:if="${@rq.member.role eq role}"
+               class="fa-regular fa-pen-to-square mr-5"></i>
+        </a>
+
     </div>
 
 </div>

--- a/src/main/resources/templates/usr/underline/fragment/category/table.html
+++ b/src/main/resources/templates/usr/underline/fragment/category/table.html
@@ -1,0 +1,27 @@
+<table th:fragment="table(categories)"
+       class="mt-5 table w-96">
+
+    <thead>
+    </thead>
+
+    <tbody>
+    <tr class="hover flex justify-between"
+        th:each="category : ${categories}"
+        th:object="${category}">
+
+        <td>
+            <a th:text="*{name}"
+               th:href="@{/underline/list/{id}(id=*{id})}"></a>
+        </td>
+        <td class="grow">
+            <a class="w-full"
+               th:href="@{/underline/list/{id}(id=*{id})}"></a>
+        </td>
+        <td>
+            <a th:text="|*{questions.size} 문제|"
+               th:href="@{/underline/list/{id}(id=*{id})}"></a>
+        </td>
+    </tr>
+    </tbody>
+
+</table>

--- a/src/main/resources/templates/usr/underline/fragment/detail/answer.html
+++ b/src/main/resources/templates/usr/underline/fragment/detail/answer.html
@@ -1,15 +1,16 @@
-<div th:fragment="content(question, mcq, check)"
+<div th:fragment="answer(question, mcq, check)"
      class="card w-80 bg-base-100 shadow-xl mt-5">
 
     <div class="card-body">
-        <p class="py-6" th:text="${question.content}"></p>
+        <span th:if="${question.type eq mcq}">선택지</span>
 
         <div th:if="${question.type eq mcq}"
              th:each="choice, roop : ${question.choiceList}"
              class="form-control">
             <label class="label cursor-pointer">
                 <span class="label-text" th:text="|${roop.count}.  ${choice.choice}|"></span>
-                <input type="radio" name="radio-10" class="radio checked:bg-red-500" th:checked="${choice.number eq check.MCQContent}" disabled/>
+                <input type="radio" name="radio-10" class="radio checked:bg-red-500"
+                       th:checked="${choice.number eq check.MCQContent}" disabled/>
             </label>
         </div>
 

--- a/src/main/resources/templates/usr/underline/fragment/detail/content.html
+++ b/src/main/resources/templates/usr/underline/fragment/detail/content.html
@@ -1,0 +1,19 @@
+<div th:fragment="content(question, underline)"
+     class="card w-80 bg-base-100 shadow-xl mt-5">
+
+    <div class="card-body">
+        <p class="py-6" th:text="${question.content}"></p>
+
+        <span>오답 노트</span>
+        <form th:action="@{/underline/update/{id}(id = ${underline.id})}"
+              method="post" class="mt-2 mb-5 flex flex-col">
+
+          <textarea th:field="${underline.about}" placeholder="오답노트"
+                    class="textarea textarea-bordered mb-5 h-32 w-full"></textarea>
+
+            <button class="btn btn-primary">오답 노트 수정</button>
+        </form>
+
+
+    </div>
+</div>

--- a/src/main/resources/templates/usr/underline/fragment/detail/nav.html
+++ b/src/main/resources/templates/usr/underline/fragment/detail/nav.html
@@ -1,0 +1,23 @@
+<div th:fragment="nav(tags, question, underline)"
+     class="mb-12 flex flex-col gap-5">
+
+    <div class="flex justify-center mt-5">
+        <span th:each="tag : ${tags}"
+              class="badge" th:text="|# ${tag.tag}  |"></span>
+    </div>
+
+    <div class="flex justify-center mt-3 mb-10 gap-5">
+
+        <a th:href="@{/underline/list/{id}(id=${question.category.id})}">
+            <i class="fa-solid fa-chevron-left"></i></a>
+
+        <span><i class="fa-regular fa-comment"></i></span>
+
+        <a href="javascript:" onclick="$(this).next().submit();">
+            <i class="fa-regular fa-trash-can"></i></a>
+
+        <form class="!hidden" hidden  method="post"
+              th:action="@{/underline/delete/{id}(id=${underline.id})}"></form>
+
+    </div>
+</div>

--- a/src/main/resources/templates/usr/underline/fragment/detail/title.html
+++ b/src/main/resources/templates/usr/underline/fragment/detail/title.html
@@ -1,0 +1,14 @@
+<div th:fragment="title(question, mcq)"
+     class="card w-80 bg-base-100 shadow-xl">
+
+
+    <div class="card-body">
+        <div class="flex justify-between">
+            <h2 class="card-title" th:text="${question.name}"></h2>
+            <span th:text="(${question.type} == ${mcq})? '객관식':'주관식'"></span>
+        </div>
+        <div class="flex" th:text="${question.category.name}"></div>
+        <div th:replace="~{usr/question/fragment/detail/difficulty :: difficulty(${question})}"></div>
+    </div>
+
+</div>

--- a/src/main/resources/templates/usr/underline/fragment/function/form.html
+++ b/src/main/resources/templates/usr/underline/fragment/function/form.html
@@ -1,0 +1,37 @@
+<form th:fragment="form(createFunctionForm, categories, types, difficulties, mcq)"
+      action="/underline/playlist" method="get"
+      th:object="${createFunctionForm}"
+      class="flex flex-col w-80 gap-4 mt-5 mb-12"
+      onsubmit="JoinForm__submit(this); return false;">
+
+
+    <label for="my-modal-3" class="mt-3">카테고리 선택 <i class="fa-solid fa-chevron-down"></i></label>
+    <input type="checkbox" id="my-modal-3" class="modal-toggle"/>
+    <div class="modal">
+        <div class="modal-box relative">
+            <label for="my-modal-3" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+            <h3 class="text-lg font-bold">카테고리를 선택해 주세요.</h3>
+
+            <div class="form-control"
+                 th:each="category : ${categories}"
+                 th:object="${category}"
+                 th:if="${category.questions.size > 0}">
+
+                <label class="label cursor-pointer">
+                    <span class="label-text" th:text="*{name}"></span>
+                    <input type="checkbox" checked="checked" class="checkbox"
+                           th:field="${createFunctionForm.categories}"
+                           th:value="*{id}"/>
+                </label>
+            </div>
+
+        </div>
+    </div>
+
+
+    <div th:replace="~{usr/question/fragment/function/type :: type(${createFunctionForm}, ${types}, ${mcq})}"></div>
+    <div th:replace="~{usr/question/fragment/function/difficulty :: difficulty(${createFunctionForm}, ${difficulties})}"></div>
+    <div th:replace="~{usr/question/fragment/function/count :: count(${createFunctionForm})}"></div>
+
+    <button class="btn btn-primary mt-3 mb-12">설정 완료</button>
+</form>

--- a/src/main/resources/templates/usr/underline/fragment/function/valid.html
+++ b/src/main/resources/templates/usr/underline/fragment/function/valid.html
@@ -1,0 +1,31 @@
+<script th:fragment="valid">
+    function JoinForm__submit(form) {
+
+        // -- categories 검증 -- //
+        var selectedCategories = Array.from(form.querySelectorAll('input[name="categories"]:checked'));
+        if (selectedCategories.length === 0) {
+            toastWarning('카테고리를 선택해 주세요.');
+            form.querySelector('input[name="categories"]').focus();
+            return false;
+        }
+
+        // -- type 검증 -- //
+        var selectedTypes = Array.from(form.querySelectorAll('input[name="type"]:checked'));
+        if (selectedTypes.length === 0) {
+            toastWarning('타입을 선택해 주세요.');
+            form.querySelector('input[name="type"]').focus();
+            return false;
+        }
+
+        // -- difficulties 검증 -- //
+        var selectedDifficulties = Array.from(form.querySelectorAll('input[name="difficulties"]:checked'));
+        if (selectedDifficulties.length === 0) {
+            toastWarning('난이도를 선택해 주세요.');
+            form.querySelector('input[name="difficulties"]').focus();
+            return false;
+        }
+
+        // -- 폼 발송 -- //
+        form.submit();
+    }
+</script>

--- a/src/main/resources/templates/usr/underline/fragment/list/table.html
+++ b/src/main/resources/templates/usr/underline/fragment/list/table.html
@@ -1,0 +1,34 @@
+<table th:fragment="table(questions, mcq)"
+       class="mt-5 table w-full">
+
+  <thead>
+  </thead>
+
+  <tbody>
+  <tr class="hover flex"
+      th:each="question, loop : ${questions}"
+      th:object="${question}">
+
+    <td>
+      <a th:text="${loop.count}"
+         th:href="@{/question/detail/{id}(id=*{id})}"></a>
+    </td>
+
+    <td class="w-24">
+      <a th:text="*{name}"
+         th:href="@{/question/detail/{id}(id=*{id})}"></a>
+    </td>
+
+    <td class="grow">
+      <a th:href="@{/question/detail/{id}(id=*{id})}">
+        <div th:replace="~{usr/question/fragment/detail/difficulty :: difficulty(${question})}"></div>
+      </a>
+    </td>
+    <td>
+      <a th:text="(*{type} == ${mcq})? '객관식':'주관식'"
+         th:href="@{/question/detail/{id}(id=*{id})}"></a>
+    </td>
+  </tr>
+  </tbody>
+
+</table>

--- a/src/main/resources/templates/usr/underline/fragment/list/table.html
+++ b/src/main/resources/templates/usr/underline/fragment/list/table.html
@@ -11,22 +11,22 @@
 
     <td>
       <a th:text="${loop.count}"
-         th:href="@{/question/detail/{id}(id=*{id})}"></a>
+         th:href="@{/underline/detail/{id}(id=*{id})}"></a>
     </td>
 
     <td class="w-24">
       <a th:text="*{name}"
-         th:href="@{/question/detail/{id}(id=*{id})}"></a>
+         th:href="@{/underline/detail/{id}(id=*{id})}"></a>
     </td>
 
     <td class="grow">
-      <a th:href="@{/question/detail/{id}(id=*{id})}">
+      <a th:href="@{/underline/detail/{id}(id=*{id})}">
         <div th:replace="~{usr/question/fragment/detail/difficulty :: difficulty(${question})}"></div>
       </a>
     </td>
     <td>
       <a th:text="(*{type} == ${mcq})? '객관식':'주관식'"
-         th:href="@{/question/detail/{id}(id=*{id})}"></a>
+         th:href="@{/underline/detail/{id}(id=*{id})}"></a>
     </td>
   </tr>
   </tbody>

--- a/src/main/resources/templates/usr/underline/top/category.html
+++ b/src/main/resources/templates/usr/underline/top/category.html
@@ -1,0 +1,11 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head><title>카테고리 목록</title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col items-center">
+
+<!--    <form th:replace="~{usr/underline/fragment/list/search :: search(${questionSearchForm})}"></form>-->
+    <table th:replace="~{usr/underline/fragment/category/table :: table(${categories})}"></table>
+
+</div>
+</html>

--- a/src/main/resources/templates/usr/underline/top/category.html
+++ b/src/main/resources/templates/usr/underline/top/category.html
@@ -4,7 +4,7 @@
 
 <div layout:fragment="content" class="min-h-screen flex flex-col items-center">
 
-<!--    <form th:replace="~{usr/underline/fragment/list/search :: search(${questionSearchForm})}"></form>-->
+    <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>
     <table th:replace="~{usr/underline/fragment/category/table :: table(${categories})}"></table>
 
 </div>

--- a/src/main/resources/templates/usr/underline/top/detail.html
+++ b/src/main/resources/templates/usr/underline/top/detail.html
@@ -1,0 +1,12 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head><title>카드 문제</title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col items-center gap-5 bg-base-200 mb-12">
+  <div class="mt-5"/>
+  <div th:replace="~{usr/underline/fragment/detail/title :: title(${question}, ${mcq})}"></div>
+  <div th:replace="~{usr/underline/fragment/detail/content :: content(${question}, ${underline})}"></div>
+  <div th:replace="~{usr/underline/fragment/detail/answer :: answer(${question}, ${mcq}, ${check})}"></div>
+  <div th:replace="~{usr/underline/fragment/detail/nav :: nav(${question.tags}, ${question}, ${underline})}"></div>
+</div>
+</html>

--- a/src/main/resources/templates/usr/underline/top/function.html
+++ b/src/main/resources/templates/usr/underline/top/function.html
@@ -1,0 +1,11 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head><title>밑줄친 문제 플레이</title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col items-center gap-12 bg-base-200">
+
+  <div th:replace="~{usr/underline/fragment/function/valid :: valid}"></div>
+  <form th:replace="~{usr/underline/fragment/function/form :: form(${createFunctionForm}, ${categories}, ${types}, ${difficulties}, ${mcq})}"></form>
+
+</div>
+</html>

--- a/src/main/resources/templates/usr/underline/top/list.html
+++ b/src/main/resources/templates/usr/underline/top/list.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/usr/underline/top/list.html
+++ b/src/main/resources/templates/usr/underline/top/list.html
@@ -6,9 +6,9 @@
 
     <div th:text="${category.about}" class="ml-10"></div>
 
-<!--    <div class="mt-5 flex justify-center">-->
-<!--        <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>-->
-<!--    </div>-->
+    <div class="mt-5 flex justify-center">
+        <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>
+    </div>
 
     <form th:replace="~{usr/underline/fragment/list/table :: table(${questions}, ${mcq})}"></form>
 

--- a/src/main/resources/templates/usr/underline/top/list.html
+++ b/src/main/resources/templates/usr/underline/top/list.html
@@ -1,10 +1,16 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
 
-</body>
+<head><title th:text="|${category.name} 문제 목록|"></title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col mb-12">
+
+    <div th:text="${category.about}" class="ml-10"></div>
+
+<!--    <div class="mt-5 flex justify-center">-->
+<!--        <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>-->
+<!--    </div>-->
+
+    <form th:replace="~{usr/underline/fragment/list/table :: table(${questions}, ${mcq})}"></form>
+
+</div>
 </html>

--- a/src/test/java/com/twenty/inhub/boundedContext/underline/UnderlineServiceTest.java
+++ b/src/test/java/com/twenty/inhub/boundedContext/underline/UnderlineServiceTest.java
@@ -34,15 +34,15 @@ class UnderlineServiceTest {
     @Test
     void Member_Category_로_Underline_조회() {
         Member member = member("member");
+        Member member2 = member("member2");
         Category category1 = category("category1");
         Category category2 = category("category2");
         for (int i = 0; i < 5; i++) {
             Question question1 = question("Q" + i, category1, member);
             Question question2 = question("Q" + i, category2, member);
-            if (i%2 == 0)
-                underline(question1, member);
-            else
-                underline(question2, member);
+            if (i%2 == 0) underline(question1, member);
+            else underline(question2, member);
+            underline(question1, member2);
         }
 
         List<Question> all = questionService.findAll();
@@ -51,9 +51,11 @@ class UnderlineServiceTest {
 
         List<Underline> underline1 = underlineService.findByCategory(member, category1);
         List<Underline> underline2 = underlineService.findByCategory(member, category2);
+        List<Underline> underline3 = underlineService.findByCategory(member2, category1);
 
         assertThat(underline1.size()).isEqualTo(3);
         assertThat(underline2.size()).isEqualTo(2);
+        assertThat(underline3.size()).isEqualTo(5);
     }
 
     private void underline(Question question, Member member) {

--- a/src/test/java/com/twenty/inhub/boundedContext/underline/UnderlineServiceTest.java
+++ b/src/test/java/com/twenty/inhub/boundedContext/underline/UnderlineServiceTest.java
@@ -1,0 +1,77 @@
+package com.twenty.inhub.boundedContext.underline;
+
+import com.twenty.inhub.boundedContext.category.Category;
+import com.twenty.inhub.boundedContext.category.CategoryService;
+import com.twenty.inhub.boundedContext.category.form.CreateCategoryForm;
+import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.member.entity.MemberRole;
+import com.twenty.inhub.boundedContext.member.service.MemberService;
+import com.twenty.inhub.boundedContext.question.controller.form.CreateQuestionForm;
+import com.twenty.inhub.boundedContext.question.entity.Question;
+import com.twenty.inhub.boundedContext.question.entity.QuestionType;
+import com.twenty.inhub.boundedContext.question.service.QuestionService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+@Transactional
+class UnderlineServiceTest {
+
+    @Autowired private MemberService memberService;
+    @Autowired private UnderlineService underlineService;
+    @Autowired private CategoryService categoryService;
+    @Autowired private QuestionService questionService;
+
+
+    @Test
+    void Member_Category_로_Underline_조회() {
+        Member member = member("member");
+        Category category1 = category("category1");
+        Category category2 = category("category2");
+        for (int i = 0; i < 5; i++) {
+            Question question1 = question("Q" + i, category1, member);
+            Question question2 = question("Q" + i, category2, member);
+            if (i%2 == 0)
+                underline(question1, member);
+            else
+                underline(question2, member);
+        }
+
+        List<Question> all = questionService.findAll();
+        assertThat(all.size()).isEqualTo(10);
+        assertThat(member.getUnderlines().size()).isEqualTo(5);
+
+        List<Underline> underline1 = underlineService.findByCategory(member, category1);
+        List<Underline> underline2 = underlineService.findByCategory(member, category2);
+
+        assertThat(underline1.size()).isEqualTo(3);
+        assertThat(underline2.size()).isEqualTo(2);
+    }
+
+    private void underline(Question question, Member member) {
+        underlineService.create("about", member, question);
+    }
+
+
+    private Question question(String name, Category category, Member member) {
+        return questionService.create(new CreateQuestionForm(name, name, "", null, null, QuestionType.SAQ), member, category).getData();
+    }
+
+    private Category category(String name) {
+        return categoryService.create(new CreateCategoryForm(name, "")).getData();
+    }
+
+    private Member member(String name) {
+        Member member = memberService.create(name, "1234").getData();
+        member.setRole(MemberRole.ADMIN);
+        return member;
+    }
+}


### PR DESCRIPTION
### 오류 수정

- 랜덤 문제 풀기 객관식 에서 이전 문제로 돌아가면 내가 입력한 답 표시 안되는 문제 해결

### 업데이트 내용

- 밑줄친 문제만 랜덤으로 풀기 기능 구현
    - 어느곳에 버튼을 만들지 정하지 않아서 아직 url 로만 입장 가능합니다.
    - 엔트포인트 : /underline/function
- 전제 문제 목록 검색기능에 밑줄문제만 모아보는 기능 구현
    - 하단의 아이콘을 누르면 밑줄 문제 카테고리 목록만 확인가능
        - 포함된 문제 숫자는 적용안됨
        - 추후에 반영할 예정입니다.
- 밑줄 문제 오답노트 수정 기능 구현
    - 밑줄 문제 상세페이지에서 확인할 수 있습니다.
    - 해당 페이지는 아직 url 로만 입장이 가능합니다.
    - 엔드포인트 : /underline/detail/{id}
- 밑줄 문제 삭제 기능 구현
    - 밑줄 문제 상세페이지에서 확인할 수 있습니다.