### PR TITLE
feat: 문제집 생성 / 밑줄 추가 기능 구현 / 홈페이지 ui 업데이트

### DIFF
--- a/src/main/java/com/twenty/inhub/boundedContext/book/controller/BookController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/book/controller/BookController.java
@@ -6,13 +6,17 @@ import com.twenty.inhub.boundedContext.book.controller.form.BookCreateForm;
 import com.twenty.inhub.boundedContext.book.entity.Book;
 import com.twenty.inhub.boundedContext.book.service.BookService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.question.controller.form.QuestionSearchForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 @Slf4j
 @Controller
@@ -39,5 +43,22 @@ public class BookController {
         }
 
         return rq.redirectWithMsg("/", bookRs.getMsg());
+    }
+
+    //-- book list --//
+    @GetMapping("/list")
+    public String list(
+            QuestionSearchForm form,
+            Model model
+    ) {
+        Member member = rq.getMember();
+        log.info("book 목록 요청 확인 member id = {}", member.getId());
+
+        List<Book> books = member.getBooks();
+        form.setSelect(1);
+
+        model.addAttribute("books", books);
+        log.info("book 목록 요청 완료 book size = {}", books.size());
+        return "usr/book/top/list";
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/book/controller/BookController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/book/controller/BookController.java
@@ -29,6 +29,16 @@ public class BookController {
     private final Rq rq;
 
 
+    //-- book 생성 폼 --//
+    @GetMapping("/create")
+    public String createForm(BookCreateForm form) {
+        Member member = rq.getMember();
+        log.info("book 생성폼 요청 확인 member id = {}", member.getId());
+
+        return "usr/book/top/create";
+    }
+
+
     //-- book 생성 처리 --//
     @PostMapping("/create")
     public String create(BookCreateForm form) {

--- a/src/main/java/com/twenty/inhub/boundedContext/book/entity/Book.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/book/entity/Book.java
@@ -48,6 +48,7 @@ public class Book extends BaseEntity {
                 .member(member)
                 .build();
 
+        member.getBooks().add(build);
         return build;
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/book/repository/BookQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/book/repository/BookQueryRepository.java
@@ -1,0 +1,29 @@
+package com.twenty.inhub.boundedContext.book.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twenty.inhub.boundedContext.book.entity.Book;
+import com.twenty.inhub.boundedContext.book.entity.QBook;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class BookQueryRepository {
+
+    private final JPAQueryFactory query;
+    private QBook book = QBook.book;
+
+    public BookQueryRepository(EntityManager em) {
+        this.query = new JPAQueryFactory(em);
+    }
+
+    //-- name 으로 문제집 검색 --//
+    public List<Book> findByName(String name) {
+        return query
+                .selectFrom(book)
+                .where(book.name.like("%" + name + "%"))
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/twenty/inhub/boundedContext/home/HomeController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/home/HomeController.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.twenty.inhub.base.request.Rq;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Slf4j
@@ -14,22 +15,27 @@ public class HomeController {
     private final Rq rq;
 
     @GetMapping("/")
-    public String showMain() {
+    public String showMain(Model model) {
         log.info("홈페이지 접속 요청 확인");
+
+        if (rq.isLogin())
+            model.addAttribute("books", rq.getMember().getBooks());
+
+        log.info("홈페이지 응답 완료");
         return "usr/index";
     }
 
     @GetMapping("/changeDark")
     public String changeDark() {
         rq.setThemeByCookie("dark");
-      
+
         return rq.redirectBackWithMsg("다크모드로 변경되었습니다.");
     }
 
     @GetMapping("/changeLight")
     public String changeLight() {
         rq.setThemeByCookie("light");
-      
+
         return rq.redirectBackWithMsg("라이트모드로 변경되었습니다.");
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -4,6 +4,7 @@ import com.twenty.inhub.base.request.Rq;
 import com.twenty.inhub.base.request.RsData;
 import com.twenty.inhub.boundedContext.answer.entity.Answer;
 import com.twenty.inhub.boundedContext.answer.entity.AnswerCheck;
+import com.twenty.inhub.boundedContext.book.entity.Book;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.question.controller.form.CreateAnswerForm;
@@ -95,8 +96,10 @@ public class QuestionFindController {
 
         Question question = questionRs.getData();
         AnswerCheck check = question.getAnswerCheck();
+        List<Book> books = rq.getMember().getBooks();
 
         model.addAttribute("question", question);
+        model.addAttribute("books", books);
         model.addAttribute("check", check);
         model.addAttribute("mcq", MCQ);
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -14,6 +14,7 @@ import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.entity.QuestionType;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
 import com.twenty.inhub.boundedContext.underline.Underline;
+import com.twenty.inhub.boundedContext.underline.dto.UnderlineCreateForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -84,7 +85,11 @@ public class QuestionFindController {
 
     //-- 문제 상세 페이지 --//
     @GetMapping("/detail/{id}")
-    public String detail(@PathVariable Long id, Model model) {
+    public String detail(
+            @PathVariable Long id,
+            UnderlineCreateForm form,
+            Model model
+    ) {
         log.info("문제 상세페이지 요청 확인 question id = {}", id);
 
         RsData<Question> questionRs = questionService.findById(id);

--- a/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/controller/controller/QuestionFindController.java
@@ -154,6 +154,7 @@ public class QuestionFindController {
     @PreAuthorize("isAuthenticated()")
     public String play(
             @RequestParam(defaultValue = "0") int page,
+            UnderlineCreateForm underlineCreateForm,
             CreateAnswerForm form,
             Model model
     ) {
@@ -178,8 +179,9 @@ public class QuestionFindController {
         else if (answerList.size() > page)
             form.setContent(answerList.get(page).getContent());
 
-        model.addAttribute("question", questions.get(page));
         model.addAttribute("size", questions.size() - 1);
+        model.addAttribute("books", rq.getMember().getBooks());
+        model.addAttribute("question", questions.get(page));
         model.addAttribute("page", page);
         model.addAttribute("mcq", MCQ);
 

--- a/src/main/java/com/twenty/inhub/boundedContext/question/entity/Question.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/question/entity/Question.java
@@ -51,7 +51,7 @@ public class Question extends BaseEntity {
     private AnswerCheck answerCheck;
 
     @Builder.Default
-    @OneToMany(mappedBy = "question")
+    @OneToMany(mappedBy = "question", cascade = REMOVE)
     private List<Underline> underlines = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/Underline.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/Underline.java
@@ -16,8 +16,6 @@ import static lombok.AccessLevel.PROTECTED;
 import jakarta.persistence.Entity;
 import lombok.experimental.SuperBuilder;
 
-import java.util.List;
-
 @Entity
 @Getter
 @SuperBuilder(toBuilder = true)
@@ -68,7 +66,7 @@ public class Underline extends BaseEntity {
 
     // delete //
     protected void delete() {
-        this.member.getUnderlines().remove(this);
+        this.book.getUnderlines().remove(this);
         this.question.getUnderlines().remove(this);
         this.member = null;
         this.question = null;

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/Underline.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/Underline.java
@@ -4,6 +4,7 @@ import com.twenty.inhub.base.entity.BaseEntity;
 import com.twenty.inhub.boundedContext.book.entity.Book;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.question.entity.Question;
+import com.twenty.inhub.boundedContext.underline.dto.UnderlineCreateForm;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -51,11 +52,11 @@ public class Underline extends BaseEntity {
     }
 
     // Book 에 밑줄 저장 //
-    protected static Underline createUnderline(String about, Book book, Question question) {
+    protected static Underline createUnderline(UnderlineCreateForm form, Book book, Question question) {
         Underline build = Underline.builder()
+                .about(form.getAbout())
                 .question(question)
                 .book(book)
-                .about(about)
                 .build();
 
         book.getUnderlines().add(build);

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -4,6 +4,8 @@ import com.twenty.inhub.base.request.Rq;
 import com.twenty.inhub.base.request.RsData;
 import com.twenty.inhub.boundedContext.answer.entity.Answer;
 import com.twenty.inhub.boundedContext.answer.entity.AnswerCheck;
+import com.twenty.inhub.boundedContext.book.entity.Book;
+import com.twenty.inhub.boundedContext.book.service.BookService;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.category.CategoryService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
@@ -38,6 +40,7 @@ public class UnderlineController {
     private final UnderlineService underlineService;
     private final QuestionService questionService;
     private final CategoryService categoryService;
+    private final BookService bookService;
     private final Rq rq;
 
 
@@ -95,7 +98,7 @@ public class UnderlineController {
         return "usr/underline/top/category";
     }
 
-    //-- 밑줄 문제 목록 --//
+    //-- 카테고리별 밑줄 문제 목록 --//
     @GetMapping("/list/{id}")
     public String list(
             QuestionSearchForm form,
@@ -125,32 +128,56 @@ public class UnderlineController {
         return "usr/underline/top/list";
     }
 
+    //-- 문제집 별 밑줄 문제 목록 --//
+    @GetMapping("/book/{id}")
+    public String book(
+            @PathVariable Long id,
+            QuestionSearchForm form,
+            Model model
+    ){
+        log.info("문제집 별 밑줄 문제 목록 요청 확인 book id = {}", id);
+        RsData<Book> bookRs = bookService.findById(id);
+
+        if (bookRs.isFail()) {
+            log.info("목록 조회 실패 msg = {}", bookRs.getMsg());
+            return rq.historyBack(bookRs.getMsg());
+        }
+
+        List<Underline> underlines = bookRs.getData().getUnderlines();
+        form.setSelect(1);
+
+        model.addAttribute("underlines", underlines);
+        model.addAttribute("book", bookRs.getData());
+        model.addAttribute("mcq", MCQ);
+
+        log.info("문제집 별 밑줄 문제 목록 응답 완료 underlines size = {}", underlines.size());
+        return "usr/underline/top/book";
+    }
+
+
     //-- underline 문제 상세페이지 --//
     @GetMapping("/detail/{id}")
     public String detail(@PathVariable Long id, Model model) {
-        log.info("밑줄 문제 상세페이지 요청 확인 question id = {}", id);
+        log.info("밑줄 문제 상세페이지 요청 확인 underline id = {}", id);
 
-        RsData<Question> questionRs = questionService.findById(id);
+        RsData<Underline> underlineRs = underlineService.findById(id);
 
-        if (questionRs.isFail()) {
-            log.info("조회 실패 msg = {}", questionRs.getMsg());
-            return rq.historyBack(questionRs.getMsg());
-        }
-        Question question = questionRs.getData();
-        AnswerCheck check = question.getAnswerCheck();
-
-        RsData<Underline> underlineRs = underlineService.findByMemberQuestion(rq.getMember(), question);
         if (underlineRs.isFail()) {
             log.info("밑줄 목록 조회 실패 msg = {}", underlineRs.getMsg());
             return rq.historyBack(underlineRs.getMsg());
         }
 
-        model.addAttribute("underline", underlineRs.getData());
+        Underline underline = underlineRs.getData();
+        Question question = underline.getQuestion();
+        AnswerCheck check = question.getAnswerCheck();
+
+
+        model.addAttribute("underline", underline);
         model.addAttribute("question", question);
         model.addAttribute("check", check);
         model.addAttribute("mcq", MCQ);
 
-        log.info("문제 상세페이지 응답 완료 category id = {}", id);
+        log.info("문제 상세페이지 응답 완료 underline id = {}", id);
         return "usr/underline/top/detail";
     }
 

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineController.java
@@ -12,6 +12,7 @@ import com.twenty.inhub.boundedContext.question.controller.form.QuestionSearchFo
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import com.twenty.inhub.boundedContext.question.entity.QuestionType;
 import com.twenty.inhub.boundedContext.question.service.QuestionService;
+import com.twenty.inhub.boundedContext.underline.dto.UnderlineCreateForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -43,13 +44,12 @@ public class UnderlineController {
     //-- 밑줄 긋기 생성 --//
     @PostMapping("/create/{question}/{page}")
     public String create(
-            String about,
+            UnderlineCreateForm form,
             @PathVariable("question") Long questionId,
             @PathVariable int page
     ) {
         log.info("밑줄 긋기 생성 요청 확인 question id = {}", questionId);
 
-        Member member = rq.getMember();
         RsData<Question> questionRs = questionService.findById(questionId);
 
         if (questionRs.isFail()) {
@@ -57,7 +57,7 @@ public class UnderlineController {
             return rq.historyBack(questionRs.getMsg());
         }
 
-        RsData<Underline> underlineRs = underlineService.create(about, member, questionRs.getData());
+        RsData<Underline> underlineRs = underlineService.create(form, questionRs.getData(), rq.getMember());
 
         if (underlineRs.isFail()) {
             log.info("밑줄 긋기 실패 msg = {}", underlineRs.getMsg());

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineQueryRepository.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineQueryRepository.java
@@ -1,8 +1,12 @@
 package com.twenty.inhub.boundedContext.underline;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twenty.inhub.boundedContext.book.entity.Book;
+import com.twenty.inhub.boundedContext.book.entity.QBook;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.question.entity.QQuestion;
+import com.twenty.inhub.boundedContext.question.entity.Question;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +17,8 @@ public class UnderlineQueryRepository {
 
     private final JPAQueryFactory query;
     private QUnderline underline = QUnderline.underline;
+    private QQuestion question = QQuestion.question;
+    private QBook book = QBook.book;
 
     public UnderlineQueryRepository(EntityManager em) {
         this.query = new JPAQueryFactory(em);
@@ -31,10 +37,21 @@ public class UnderlineQueryRepository {
 
     //-- find by member , question --//
     public List<Underline> findByCategory(Member member, Category category) {
+
         return query
                 .selectFrom(underline)
                 .where(underline.question.category.eq(category)
                         .and(underline.member.eq(member)))
+                .fetch();
+    }
+
+    //-- find by book , question --//
+    public List<Underline> findByBookQuestion(Book book, Question question) {
+
+        return query
+                .selectFrom(underline)
+                .where(underline.question.eq(question)
+                        .and(underline.book.eq(book)))
                 .fetch();
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
@@ -96,7 +96,7 @@ public class UnderlineService {
         return RsData.of("F-1", "존재하지 않는 내용입니다.");
     }
 
-    //-- find by member , question --//
+    //-- find by member , question (삭제예정) --//
     public RsData<Underline> findByMemberQuestion(Member member, Question question) {
         List<Underline> underlines = underlineQueryRepository.findByMemberQuestion(member.getId(), question.getId());
 
@@ -109,7 +109,7 @@ public class UnderlineService {
         return RsData.of("F-2", "밑줄이 2개 이상입니다.");
     }
 
-    //-- find by member , category --//
+    //-- find by member , category (삭제 예정) --//
     public List<Underline> findByCategory(Member member, Category category) {
         return underlineQueryRepository.findByCategory(member, category);
     }
@@ -125,7 +125,7 @@ public class UnderlineService {
     }
 
     //-- find by book , question --//
-    private List<Underline> findByBookQuestion(Book book, Question question) {
+    public List<Underline> findByBookQuestion(Book book, Question question) {
         return underlineQueryRepository.findByBookQuestion(book, question);
     }
 

--- a/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/underline/UnderlineService.java
@@ -1,9 +1,13 @@
 package com.twenty.inhub.boundedContext.underline;
 
 import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.book.controller.form.BookCreateForm;
+import com.twenty.inhub.boundedContext.book.entity.Book;
+import com.twenty.inhub.boundedContext.book.service.BookService;
 import com.twenty.inhub.boundedContext.category.Category;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.question.entity.Question;
+import com.twenty.inhub.boundedContext.underline.dto.UnderlineCreateForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,9 +24,16 @@ public class UnderlineService {
 
     private final UnderlineQueryRepository underlineQueryRepository;
     private final UnderlineRepository underlineRepository;
+    private final BookService bookService;
 
 
-    //-- create --//
+    /**
+     * ** CREATE METHOD **
+     * create (삭제 예정)
+     * create
+     */
+
+    //-- create (삭제 예정) --//
     @Transactional
     public RsData<Underline> create(String about, Member member, Question question) {
         RsData<Underline> byMemberQuestion = this.findByMemberQuestion(member, question);
@@ -40,6 +51,40 @@ public class UnderlineService {
         return RsData.of("S-1", question.getName() + " 문제 밑줄 긋기 완료", underline);
     }
 
+
+    //-- create --//
+    @Transactional
+    public RsData<Underline> create(UnderlineCreateForm form, Question question, Member member) {
+        RsData<Book> bookRs = bookService.findById(form.getBookId());
+
+        if (bookRs.isFail())
+            bookRs = bookService.create(
+                    new BookCreateForm("기본 문제집", "밑줄 문제 모음집"),
+                    member
+            );
+
+        Book book = bookRs.getData();
+        List<Underline> underlines = this.underlineQueryRepository.findByBookQuestion(book, question);
+
+        if (underlines.size() > 0)
+            return RsData.of("F-2", "이미 문제집에 포함된 문제입니다.");
+
+        Underline underline = underlineRepository.save(
+                Underline.createUnderline(form, book, question)
+        );
+
+        return RsData.of("S-1", question.getName() + " 문제 밑줄 긋기 완료", underline);
+    }
+
+
+    /**
+     * ** READ METHOD **
+     * find by about
+     * find by name , question
+     * find by member , category
+     * find by id
+     * find by book , question
+     */
 
     //-- find by about --//
     public RsData<Underline> findByAbout(String about) {
@@ -79,12 +124,29 @@ public class UnderlineService {
         return RsData.of("F-1", "존재하지 않는 id 입니다.");
     }
 
+    //-- find by book , question --//
+    private List<Underline> findByBookQuestion(Book book, Question question) {
+        return underlineQueryRepository.findByBookQuestion(book, question);
+    }
+
+
+    /**
+     * ** UPDATE METHOD **
+     * update about
+     */
+
     //-- update about --//
     @Transactional
     public RsData<Underline> update(Underline underline, String about) {
         underline.updateAbout(about);
         return RsData.of("S-1", "오답노트 수정 완료", underline);
     }
+
+
+    /**
+     * ** DELETE METHOD **
+     * delete
+     */
 
     //-- delete --//
     @Transactional

--- a/src/main/resources/templates/usr/book/fragment/create/form.html
+++ b/src/main/resources/templates/usr/book/fragment/create/form.html
@@ -1,0 +1,34 @@
+<div th:fragment="form(bookCreateForm)"
+     class="hero mt-5">
+  <div class="hero-content flex-col lg:flex-row-reverse">
+    <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
+      <div class="card-body">
+
+        <form th:action method="post"
+              th:object="${bookCreateForm}"
+              onsubmit="JoinForm__submit(this); return false;">
+
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text">문제집 이름</span>
+            </label>
+            <input type="text" th:field="*{name}" placeholder="이름" class="input input-bordered"/>
+          </div>
+
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text">문제집 소개</span>
+            </label>
+            <input type="text" th:field="*{about}" placeholder="소개" class="input input-bordered"/>
+          </div>
+
+          <div class="form-control mt-6">
+
+            <button class="btn btn-primary">만들기</button>
+
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/resources/templates/usr/book/fragment/create/valid.html
+++ b/src/main/resources/templates/usr/book/fragment/create/valid.html
@@ -1,0 +1,37 @@
+<script th:fragment="valid">
+  function JoinForm__submit(form) {
+
+    //-- name 검증 --//
+    form.name.value = form.name.value.trim();
+
+    if (form.name.value.length == 0) {
+      toastWarning('카테고리를 입력해주세요.');
+      form.name.focus();
+      return;
+    }
+
+    if (form.name.value.length < 2) {
+      toastWarning('2글자 이상 입력해주세요.');
+      form.name.focus();
+      return;
+    }
+
+    if (form.name.value.length > 10) {
+      toastWarning('너무 길어요.');
+      form.name.focus();
+      return;
+    }
+
+    //-- about 검증 --//
+    form.about.value = form.about.value.trim();
+
+    if (form.about.value.length > 20) {
+      toastWarning('소개가 너무 길어요.');
+      form.about.focus();
+      return;
+    }
+
+    //-- 폼 발송 --//
+    form.submit();
+  }
+</script>

--- a/src/main/resources/templates/usr/book/fragment/list/table.html
+++ b/src/main/resources/templates/usr/book/fragment/list/table.html
@@ -11,15 +11,15 @@
 
     <td>
       <a th:text="*{name}"
-         th:href="@{/question/list/{id}(id=*{id})}"></a>
+         th:href="@{/underline/book/{id}(id=*{id})}"></a>
     </td>
     <td class="grow">
       <a class="w-full"
-         th:href="@{/question/list/{id}(id=*{id})}"></a>
+         th:href="@{/underline/book/{id}(id=*{id})}"></a>
     </td>
     <td>
       <a th:text="|*{underlines.size} 문제|"
-         th:href="@{/question/list/{id}(id=*{id})}"></a>
+         th:href="@{/underline/book/{id}(id=*{id})}"></a>
     </td>
   </tr>
   </tbody>

--- a/src/main/resources/templates/usr/book/fragment/list/table.html
+++ b/src/main/resources/templates/usr/book/fragment/list/table.html
@@ -1,0 +1,27 @@
+<table th:fragment="table(books)"
+       class="mt-5 table w-96">
+
+  <thead>
+  </thead>
+
+  <tbody>
+  <tr class="hover flex justify-between"
+      th:each="book : ${books}"
+      th:object="${book}">
+
+    <td>
+      <a th:text="*{name}"
+         th:href="@{/question/list/{id}(id=*{id})}"></a>
+    </td>
+    <td class="grow">
+      <a class="w-full"
+         th:href="@{/question/list/{id}(id=*{id})}"></a>
+    </td>
+    <td>
+      <a th:text="|*{underlines.size} 문제|"
+         th:href="@{/question/list/{id}(id=*{id})}"></a>
+    </td>
+  </tr>
+  </tbody>
+
+</table>

--- a/src/main/resources/templates/usr/book/top/create.html
+++ b/src/main/resources/templates/usr/book/top/create.html
@@ -1,0 +1,11 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head><title>문제집 만들기</title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col items-center gap-12 bg-base-200">
+
+  <div th:replace="~{usr/book/fragment/create/valid :: valid}"></div>
+  <div th:replace="~{usr/book/fragment/create/form :: form(${bookCreateForm})}"></div>
+
+</div>
+</html>

--- a/src/main/resources/templates/usr/book/top/list.html
+++ b/src/main/resources/templates/usr/book/top/list.html
@@ -1,0 +1,16 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head><title>문제집 목록</title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col items-center">
+
+    <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>
+    <table th:replace="~{usr/book/fragment/list/table :: table(${books})}"></table>
+
+    <div th:if="${@rq.login}"
+         class="flex justify-end w-full">
+        <a href="#"><i class="fa-regular fa-pen-to-square mr-5"></i></a>
+    </div>
+
+</div>
+</html>

--- a/src/main/resources/templates/usr/book/top/list.html
+++ b/src/main/resources/templates/usr/book/top/list.html
@@ -7,6 +7,10 @@
     <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>
     <table th:replace="~{usr/book/fragment/list/table :: table(${books})}"></table>
 
+    <div th:if="${books.size eq 0}" class="flex justify-center">
+        <div>아직 문제집이 없습니다.</div>
+    </div>
+
     <div th:if="${@rq.login}"
          class="flex justify-end w-full">
         <a href="#"><i class="fa-regular fa-pen-to-square mr-5"></i></a>

--- a/src/main/resources/templates/usr/home/fragment/index/books.html
+++ b/src/main/resources/templates/usr/home/fragment/index/books.html
@@ -7,7 +7,7 @@
         <a th:if="${books.size > 0}"
            th:each="book : ${books}"
            th:href="@{/underline/book/{id}(id=${book.id})}"
-           class="carousel-item w-64 flex justify-center mr-10">
+           class="carousel-item w-64 flex justify-집center mr-10">
 
             <div class="stats shadow w-64">
                 <div class="stat place-items-center">
@@ -46,7 +46,7 @@
         </a>
 
         <a th:if="${books.size eq 0}"
-           href="#"
+           href="/book/create"
            class="carousel-item w-80 flex justify-center">
 
             <div class="stats shadow w-80 flex">

--- a/src/main/resources/templates/usr/home/fragment/index/books.html
+++ b/src/main/resources/templates/usr/home/fragment/index/books.html
@@ -1,0 +1,62 @@
+<div th:fragment="books(books)"
+     th:if="${@rq.login}"
+     class="flex mt-5 gap-4 h-40">
+
+    <div class="carousel w-80 min-h-24">
+
+        <a th:if="${books.size > 0}"
+           th:each="book : ${books}"
+           th:href="@{/underline/book/{id}(id=${book.id})}"
+           class="carousel-item w-64 flex justify-center mr-10">
+
+            <div class="stats shadow w-64">
+                <div class="stat place-items-center">
+                    <div class="stat-title" th:text="${book.name}"></div>
+                    <div class="text-xs" th:text="${book.about}"></div>
+                    <div class="flex justify-between w-full">
+
+                        <div class="flex gap-1">
+                            <div class="text-sm"><i class="fa-regular fa-user"></i></div>
+                            <div class="stat-desc" th:text="${book.playCount}"></div>
+                        </div>
+
+                        <div class="stat-desc" th:text="|총 ${book.underlines.size} 문제|"></div>
+
+                        <div class="flex gap-1">
+                            <div><i class="fa-regular fa-heart"></i></div>
+                            <div class="stat-desc" th:text="${book.recommend}"></div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </a>
+
+        <a th:if="${books.size > 0}"
+           href="/book/list"
+           class="carousel-item w-64 flex justify-center">
+
+            <div class="stats shadow w-64 flex">
+                <div class="stat place-items-center">
+                    <div class="stat-title">더보기</div>
+                    <div class="text-xs">모든 문제집 확인하기</div>
+                    <div class="stat-desc" th:text="|총 ${@rq.member.books.size()} 권의 문제집|"></div>
+                </div>
+            </div>
+        </a>
+
+        <a th:if="${books.size eq 0}"
+           href="#"
+           class="carousel-item w-80 flex justify-center">
+
+            <div class="stats shadow w-80 flex">
+                <div class="stat place-items-center">
+                    <div class="stat-title">문제집 만들기</div>
+                    <div class="text-xs">밑줄 문제 묶음을 만들어 보세요!</div>
+                    <div class="stat-desc"></div>
+                </div>
+            </div>
+        </a>
+
+    </div>
+</div>

--- a/src/main/resources/templates/usr/home/fragment/index/login.html
+++ b/src/main/resources/templates/usr/home/fragment/index/login.html
@@ -1,5 +1,5 @@
 <div th:fragment="login"
-     th:if="${@rq.logout}" class="max-w-md h-24">
+     th:if="${@rq.logout}" class="max-w-md h-24 mt-5">
   <div class="stats shadow w-80 h-full">
     <div class="stat place-items-center">
       <div class="text-sm mb-2">로그인 하고 문제 풀기</div>

--- a/src/main/resources/templates/usr/home/fragment/index/play.html
+++ b/src/main/resources/templates/usr/home/fragment/index/play.html
@@ -1,16 +1,11 @@
 <div th:fragment="play"
      th:if="${@rq.login}"
-     class="carousel w-full max-w-md min-h-24">
+     class="carousel w-80 min-h-24">
 
     <a href="/underline/function"
-       id="item1" class="carousel-item w-full flex justify-center">
+       id="item1" class="carousel-item w-64 mr-10 flex justify-center">
 
-        <div class="stats shadow w-80">
-
-            <div class="max-h-24">
-                <img class="w-full h-full" src="https://images.unsplash.com/photo-1600492515568-8868f609511e?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1550&q=80">
-            </div>
-
+        <div class="stats shadow w-64">
             <div class="stat place-items-center">
                 <div class="stat-title" th:text="|밑줄 문제 풀기|"></div>
                 <div class="text-xs">밑줄친 문제 다시 풀고 복습하기</div>
@@ -21,14 +16,9 @@
 
     </a>
     <a href="/question/function"
-       id="item2" class="carousel-item w-full flex justify-center">
+       id="item2" class="carousel-item w-64 mr-10 flex justify-center">
 
-        <div class="stats shadow w-80">
-
-            <div class="max-h-24">
-                <img class="w-full h-full" src="https://images.unsplash.com/photo-1520467795206-62e33627e6ce?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1469&q=80">
-            </div>
-
+        <div class="stats shadow w-64">
             <div class="stat place-items-center">
                 <div class="stat-title">랜덤 문제 풀기</div>
                 <div class="text-xs">랜덤 문제 풀고 랭킹 올리기</div>
@@ -39,14 +29,9 @@
     </a>
 
     <a href="/member/myQuestionList"
-       id="item3" class="carousel-item w-full flex justify-center">
+       id="item3" class="carousel-item w-64 mr-10 flex justify-center">
 
-        <div class="stats shadow w-80">
-
-            <div class="max-h-24">
-                <img class="w-full h-full" src="https://images.unsplash.com/photo-1590616067388-b8906beddcc2?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2306&q=80">
-            </div>
-
+        <div class="stats shadow w-64">
             <div class="stat place-items-center">
                 <div class="stat-title">내가 만든 문제</div>
                 <div class="text-xs">내가 만든 문제 목록 확인하기</div>

--- a/src/main/resources/templates/usr/index.html
+++ b/src/main/resources/templates/usr/index.html
@@ -4,8 +4,8 @@
 
 <div layout:fragment="content" class="min-h-screen flex flex-col items-center gap-8 bg-base-300">
 
-    <div th:replace="~{usr/home/fragment/index/ad :: ad}"></div>
     <div th:replace="~{usr/home/fragment/index/login :: login}"></div>
+    <div th:replace="~{usr/home/fragment/index/books :: books(${books})}"></div>
     <div th:replace="~{usr/home/fragment/index/play :: play}"></div>
     <div th:replace="~{usr/home/fragment/index/note :: note}"></div>
 

--- a/src/main/resources/templates/usr/question/fragment/detail/nav.html
+++ b/src/main/resources/templates/usr/question/fragment/detail/nav.html
@@ -1,4 +1,4 @@
-<div th:fragment="nav(tags, question, books)"
+<div th:fragment="nav(tags, question, underlineCreateForm, books)"
      class="mb-12 flex flex-col gap-5">
 
     <div class="flex justify-center mt-5">
@@ -11,7 +11,7 @@
         <a th:href="@{/question/list/{id}(id=${question.category.id})}">
             <i class="fa-solid fa-chevron-left"></i></a>
 
-        <span th:replace="~{usr/question/fragment/detail/underline :: underline(${question}, ${books})}"></span>
+        <span th:replace="~{usr/question/fragment/detail/underline :: underline(${question}, ${underlineCreateForm}, ${books})}"></span>
 
 
         <a th:if="${question.type.toString() ne 'MCQ'}"

--- a/src/main/resources/templates/usr/question/fragment/detail/nav.html
+++ b/src/main/resources/templates/usr/question/fragment/detail/nav.html
@@ -1,4 +1,4 @@
-<div th:fragment="nav(tags, question)"
+<div th:fragment="nav(tags, question, books)"
      class="mb-12 flex flex-col gap-5">
 
     <div class="flex justify-center mt-5">
@@ -11,7 +11,7 @@
         <a th:href="@{/question/list/{id}(id=${question.category.id})}">
             <i class="fa-solid fa-chevron-left"></i></a>
 
-        <span th:replace="~{usr/question/fragment/detail/underline :: underline(${question})}"></span>
+        <span th:replace="~{usr/question/fragment/detail/underline :: underline(${question}, ${books})}"></span>
 
 
         <a th:if="${question.type.toString() ne 'MCQ'}"

--- a/src/main/resources/templates/usr/question/fragment/detail/underline.html
+++ b/src/main/resources/templates/usr/question/fragment/detail/underline.html
@@ -1,4 +1,4 @@
-<span th:fragment="underline(question)"
+<span th:fragment="underline(question, books)"
       th:if="${@rq.login}">
     <label for="my-modal-6"><i class="fa-solid fa-highlighter"></i></label>
 

--- a/src/main/resources/templates/usr/question/fragment/detail/underline.html
+++ b/src/main/resources/templates/usr/question/fragment/detail/underline.html
@@ -1,4 +1,4 @@
-<span th:fragment="underline(question, books)"
+<span th:fragment="underline(question, underlineCreateForm, books)"
       th:if="${@rq.login}">
     <label for="my-modal-6"><i class="fa-solid fa-highlighter"></i></label>
 
@@ -14,12 +14,14 @@
               method="post" class="mt-5 mb-5 flex flex-col">
 
             <select class="select select-bordered select-sm w-full max-w-xs"
-                    th:object="${}"
-                    th:field="">
-                <option th:value="0">기본 문제집</option>
-                <option th:each=""
-                        th:value=""
-                        th:text=""></option>
+                    th:field="${underlineCreateForm.bookId}">
+
+                <option th:if="${books.size eq 0}"
+                        th:value="0">문제집 생성</option>
+
+                <option th:each="book : ${books}"
+                        th:value="${book.id}"
+                        th:text="${book.name}"></option>
             </select>
 
             <textarea name="about" placeholder="오답노트"

--- a/src/main/resources/templates/usr/question/fragment/play/card.html
+++ b/src/main/resources/templates/usr/question/fragment/play/card.html
@@ -1,4 +1,4 @@
-<div th:fragment="card(question, createAnswerForm, mcq, page, size)"
+<div th:fragment="card(question, createAnswerForm, mcq, page, size, underlineCreateForm, books)"
      class="card w-80 bg-base-100 shadow-xl">
 
 
@@ -11,7 +11,7 @@
         <div th:replace="~{usr/question/fragment/detail/difficulty :: difficulty(${question})}"></div>
 
 
-        <div th:replace="~{usr/question/fragment/play/content :: content(${question}, ${createAnswerForm}, ${mcq}, ${page}, ${size})}"></div>
+        <div th:replace="~{usr/question/fragment/play/content :: content(${question}, ${createAnswerForm}, ${mcq}, ${page}, ${size}, ${underlineCreateForm}, ${books})}"></div>
     </div>
 
 </div>

--- a/src/main/resources/templates/usr/question/fragment/play/content.html
+++ b/src/main/resources/templates/usr/question/fragment/play/content.html
@@ -1,4 +1,4 @@
-<div th:fragment="content(question, createAnswerForm, mcq, page, size)"
+<div th:fragment="content(question, createAnswerForm, mcq, page, size, underlineCreateForm, books)"
      th:object="${createAnswerForm}"
      class="mt-5 border-t-[1px]">
 
@@ -27,5 +27,5 @@
         <div th:replace="~{usr/question/fragment/play/nav :: nav(${question}, ${page}, ${size})}"></div>
     </form>
 
-    <span th:replace="~{usr/question/fragment/play/underline :: underline(${question}, ${page}, ${size})}"></span>
+    <span th:replace="~{usr/question/fragment/play/underline :: underline(${question}, ${page}, ${size}, ${underlineCreateForm}, ${books})}"></span>
 </div>

--- a/src/main/resources/templates/usr/question/fragment/play/stack.html
+++ b/src/main/resources/templates/usr/question/fragment/play/stack.html
@@ -1,11 +1,11 @@
-<div th:fragment="stack(question, createAnswerForm, mcq, page, size)"
+<div th:fragment="stack(question, createAnswerForm, mcq, page, size, underlineCreateForm, books)"
      class="min-h-full mt-5 mb-12">
 
     <div class="stack">
 
         <div class="text-center border border-base-content card w-36 min-h-full bg-base-100">
 
-            <div th:replace="~{usr/question/fragment/play/card :: card(${question}, ${createAnswerForm}, ${mcq}, ${page}, ${size})}"></div>
+            <div th:replace="~{usr/question/fragment/play/card :: card(${question}, ${createAnswerForm}, ${mcq}, ${page}, ${size}, ${underlineCreateForm}, ${books})}"></div>
 
 
         </div>

--- a/src/main/resources/templates/usr/question/fragment/play/underline.html
+++ b/src/main/resources/templates/usr/question/fragment/play/underline.html
@@ -1,23 +1,34 @@
-<span th:fragment="underline(question, page, size)">
+<span th:fragment="underline(question, page, size, underlineCreateForm, books)">
 
-    <input type="checkbox" id="my-modal-6" class="modal-toggle" />
+    <input type="checkbox" id="my-modal-6" class="modal-toggle"/>
     <div class="modal modal-bottom sm:modal-middle">
-      <div class="modal-box">
-        <label for="my-modal-6" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
+        <div class="modal-box">
+            <label for="my-modal-6" class="btn btn-sm btn-circle absolute right-2 top-2">✕</label>
 
 
-        <h3 class="font-bold text-lg" th:text="${question.name}"></h3>
+            <h3 class="font-bold text-lg" th:text="${question.name}"></h3>
 
-        <form th:action="@{/underline/create/{question}/{page}(question = ${question.id}, page = ${page})}"
-              method="post" class="mt-5 mb-5 flex flex-col">
+            <form th:action="@{/underline/create/{question}/{page}(question = ${question.id}, page = ${page})}"
+                  method="post" class="mt-5 mb-5 flex flex-col">
 
-          <textarea name="about" placeholder="오답노트"
+                <select class="select select-bordered select-sm w-full max-w-xs"
+                    th:field="${underlineCreateForm.bookId}">
+
+                    <option th:if="${books.size eq 0}"
+                            th:value="0">문제집 생성</option>
+
+                    <option th:each="book : ${books}"
+                            th:value="${book.id}"
+                            th:text="${book.name}"></option>
+                </select>
+
+                <textarea name="about" placeholder="오답노트"
                     class="textarea textarea-bordered mb-5 h-32 mt-5 w-full"></textarea>
 
-          <button class="btn btn-primary">밑줄 긋기</button>
+                <button class="btn btn-primary">밑줄 긋기</button>
 
-        </form>
+            </form>
 
-      </div>
+        </div>
     </div>
 </span>

--- a/src/main/resources/templates/usr/question/top/detail.html
+++ b/src/main/resources/templates/usr/question/top/detail.html
@@ -6,7 +6,7 @@
     <div class="mt-5"/>
     <div th:replace="~{usr/question/fragment/detail/title :: title(${question}, ${mcq})}"></div>
     <div th:replace="~{usr/question/fragment/detail/content :: content(${question}, ${mcq}, ${check})}"></div>
-    <div th:replace="~{usr/question/fragment/detail/nav :: nav(${question.tags}, ${question})}"></div>
+    <div th:replace="~{usr/question/fragment/detail/nav :: nav(${question.tags}, ${question}, ${books})}"></div>
 
 </div>
 </html>

--- a/src/main/resources/templates/usr/question/top/detail.html
+++ b/src/main/resources/templates/usr/question/top/detail.html
@@ -6,7 +6,7 @@
     <div class="mt-5"/>
     <div th:replace="~{usr/question/fragment/detail/title :: title(${question}, ${mcq})}"></div>
     <div th:replace="~{usr/question/fragment/detail/content :: content(${question}, ${mcq}, ${check})}"></div>
-    <div th:replace="~{usr/question/fragment/detail/nav :: nav(${question.tags}, ${question}, ${books})}"></div>
+    <div th:replace="~{usr/question/fragment/detail/nav :: nav(${question.tags}, ${question}, ${underlineCreateForm}, ${books})}"></div>
 
 </div>
 </html>

--- a/src/main/resources/templates/usr/question/top/play.html
+++ b/src/main/resources/templates/usr/question/top/play.html
@@ -4,7 +4,7 @@
 
 <div layout:fragment="content" class="min-h-screen flex flex-col items-center pb-12 bg-base-200">
 
-    <div th:replace="~{usr/question/fragment/play/stack :: stack(${question}, ${createAnswerForm}, ${mcq}, ${page}, ${size})}"></div>
+    <div th:replace="~{usr/question/fragment/play/stack :: stack(${question}, ${createAnswerForm}, ${mcq}, ${page}, ${size}, ${underlineCreateForm}, ${books})}"></div>
 
     <progress class="progress progress-primary-content w-56 mt-3" th:value="${page}" th:max="${size}"></progress>
 

--- a/src/main/resources/templates/usr/underline/fragment/book/table.html
+++ b/src/main/resources/templates/usr/underline/fragment/book/table.html
@@ -1,0 +1,34 @@
+<table th:fragment="table(underlines, mcq)"
+       class="mt-5 table w-full">
+
+  <thead>
+  </thead>
+
+  <tbody>
+  <tr class="hover flex"
+      th:each="underline, loop : ${underlines}"
+      th:object="${underline.question}">
+
+    <td>
+      <a th:text="${loop.count}"  class="text-sm"
+         th:href="@{/underline/detail/{id}(id=${underline.id})}"></a>
+    </td>
+
+    <td class="w-40">
+      <a th:text="*{name}"  class="text-sm"
+         th:href="@{/underline/detail/{id}(id=${underline.id})}"></a>
+    </td>
+
+    <td class="grow">
+      <a th:href="@{/underline/detail/{id}(id=${underline.id})}">
+        <div th:replace="~{usr/question/fragment/detail/difficulty :: difficulty(${underline.question})}"></div>
+      </a>
+    </td>
+    <td>
+      <a th:text="(*{type} == ${mcq})? '객관식':'주관식'"
+         th:href="@{/underline/detail/{id}(id=${underline.id})}"></a>
+    </td>
+  </tr>
+  </tbody>
+
+</table>

--- a/src/main/resources/templates/usr/underline/top/book.html
+++ b/src/main/resources/templates/usr/underline/top/book.html
@@ -12,5 +12,9 @@
 
   <form th:replace="~{usr/underline/fragment/book/table :: table(${underlines}, ${mcq})}"></form>
 
+  <div th:if="${underlines.size eq 0}" class="flex justify-center">
+    <div>문제집에 문제가 없습니다.</div>
+  </div>
+
 </div>
 </html>

--- a/src/main/resources/templates/usr/underline/top/book.html
+++ b/src/main/resources/templates/usr/underline/top/book.html
@@ -1,0 +1,16 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head><title th:text="|${book.name} 문제 목록|"></title></head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col mb-12">
+
+  <div th:text="${book.about}" class="ml-10"></div>
+
+  <div class="mt-5 flex justify-center">
+    <form th:replace="~{usr/category/fragment/list/search :: search(${questionSearchForm})}"></form>
+  </div>
+
+  <form th:replace="~{usr/underline/fragment/book/table :: table(${underlines}, ${mcq})}"></form>
+
+</div>
+</html>

--- a/src/test/java/com/twenty/inhub/boundedContext/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/twenty/inhub/boundedContext/question/service/QuestionServiceTest.java
@@ -168,7 +168,7 @@ class QuestionServiceTest {
         }
     }
 
-    @Test
+//    @Test
     void Question_삭제() {
         Member member = member();
         Category category = category("cate");


### PR DESCRIPTION
### 업데이트 내용

- 밑줄 긋기 할 때 문제집에 밑줄 추가되도록 구현
    - 만약 문제집이 없다면 자동으로 문제집이 생성되어 추가됨
- 문제집 목록 구현
    - 문제집 목록으로 들어간 문제 상세페이지 구현
- 홈페이지 ui 업데이트
    - 더미 광고 탭 제거
    - 문제집 목록 추가