### PR TITLE
feat: 쪽지 알림 기능

### DIFF
--- a/src/main/generated/com/twenty/inhub/boundedContext/member/entity/QMember.java
+++ b/src/main/generated/com/twenty/inhub/boundedContext/member/entity/QMember.java
@@ -48,7 +48,11 @@ public class QMember extends EntityPathBase<Member> {
 
     public final ListPath<com.twenty.inhub.boundedContext.question.entity.Question, com.twenty.inhub.boundedContext.question.entity.QQuestion> questions = this.<com.twenty.inhub.boundedContext.question.entity.Question, com.twenty.inhub.boundedContext.question.entity.QQuestion>createList("questions", com.twenty.inhub.boundedContext.question.entity.Question.class, com.twenty.inhub.boundedContext.question.entity.QQuestion.class, PathInits.DIRECT2);
 
+    public final ListPath<com.twenty.inhub.boundedContext.note.entity.Note, com.twenty.inhub.boundedContext.note.entity.QNote> receiveList = this.<com.twenty.inhub.boundedContext.note.entity.Note, com.twenty.inhub.boundedContext.note.entity.QNote>createList("receiveList", com.twenty.inhub.boundedContext.note.entity.Note.class, com.twenty.inhub.boundedContext.note.entity.QNote.class, PathInits.DIRECT2);
+
     public final EnumPath<MemberRole> role = createEnum("role", MemberRole.class);
+
+    public final ListPath<com.twenty.inhub.boundedContext.note.entity.Note, com.twenty.inhub.boundedContext.note.entity.QNote> sendList = this.<com.twenty.inhub.boundedContext.note.entity.Note, com.twenty.inhub.boundedContext.note.entity.QNote>createList("sendList", com.twenty.inhub.boundedContext.note.entity.Note.class, com.twenty.inhub.boundedContext.note.entity.QNote.class, PathInits.DIRECT2);
 
     public final EnumPath<MemberStatus> status = createEnum("status", MemberStatus.class);
 

--- a/src/main/java/com/twenty/inhub/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.twenty.inhub.base.appConfig.AppConfig;
 import com.twenty.inhub.boundedContext.answer.entity.Answer;
 import com.twenty.inhub.boundedContext.book.entity.Book;
 import com.twenty.inhub.boundedContext.comment.entity.Comment;
+import com.twenty.inhub.boundedContext.note.entity.Note;
 import com.twenty.inhub.boundedContext.post.entity.Post;
 import com.twenty.inhub.boundedContext.question.entity.Question;
 import jakarta.persistence.*;
@@ -74,6 +75,12 @@ public class Member {
     @OneToMany
     @Builder.Default
     private List<Book> books = new ArrayList<>();
+    @OneToMany(mappedBy = "receiver")
+    @Builder.Default
+    private List<Note> receiveList = new ArrayList<>();
+    @OneToMany(mappedBy = "sender")
+    @Builder.Default
+    private List<Note> sendList = new ArrayList<>();
 
     //-- create authorize --//
     public List<? extends GrantedAuthority> getGrantedAuthorities() {
@@ -104,6 +111,16 @@ public class Member {
 
     public boolean hasSocialProfile() {
         return profileImg.contains("http");
+    }
+
+    public int getNewReceiveCount() {
+        return (int) receiveList.stream()
+                .filter(note -> note.getReadDate() == null)
+                .count();
+    }
+
+    public int getAllReceiveCount() {
+        return receiveList.size();
     }
 
     @Override

--- a/src/main/java/com/twenty/inhub/boundedContext/note/service/NoteService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/note/service/NoteService.java
@@ -41,6 +41,9 @@ public class NoteService {
                 .receiver(opReceiver.get())
                 .build();
 
+        sender.getSendList().add(note);
+        opReceiver.get().getReceiveList().add(note);
+
         Note saved = noteRepository.save(note);
 
         return RsData.of("S-1", "쪽지를 성공적으로 보냈습니다.", saved);
@@ -58,9 +61,11 @@ public class NoteService {
 
         if(member.getNickname().equals(note.getSender().getNickname())) {
             note.setDeleteSender(true);
+            note.setReadDate(LocalDateTime.now());
             rsData = RsData.of("S-1", "보낸 쪽지가 삭제되었습니다.");
         } else {
             note.setDeleteReceiver(true);
+            note.setReadDate(LocalDateTime.now());
             rsData = RsData.of("S-2", "받은 쪽지가 삭제되었습니다.");
         }
 

--- a/src/main/resources/templates/layout/top-navbar.html
+++ b/src/main/resources/templates/layout/top-navbar.html
@@ -13,9 +13,9 @@
             </a>
         </div>
     </div>
-    <div class="flex-none">
+    <div class="flex-none mr-3">
         <div class="dropdown dropdown-end">
-            <label th:if="${@rq.login}" tabindex="0" class="btn btn-ghost btn-circle avatar">
+            <label th:if="${@rq.login}" tabindex="0" class="btn btn-ghost btn-circle avatar" th:classappend="${@rq.member.newReceiveCount > 0} ? 'online' : ''">
                 <div class="w-10 rounded-full">
                     <div th:if="${@rq.member.profileImg != null && !@rq.hasSocialProfile()}">
                         <img th:src="@{/images/profile/{filename}(filename=${@rq.member.profileImg})}">

--- a/src/main/resources/templates/usr/member/mypage.html
+++ b/src/main/resources/templates/usr/member/mypage.html
@@ -115,7 +115,12 @@
             </li>
             <li><a href="/note/send">쪽지 보내기</a></li>
             <li><a href="/note/sendList">보낸 쪽지함</a></li>
-            <li><a href="/note/receiveList">받은 쪽지함</a></li>
+            <li>
+                <a href="/note/receiveList">
+                    받은 쪽지함
+                    <span th:if="${@rq.member.newReceiveCount > 0}" class="badge badge-secondary" th:text="|${@rq.member.newReceiveCount} NEW|"></span>
+                </a>
+            </li>
             <li class="menu-title mt-3">
                 <span>통계</span>
             </li>

--- a/src/main/resources/templates/usr/note/receiveList.html
+++ b/src/main/resources/templates/usr/note/receiveList.html
@@ -16,12 +16,12 @@
                         <th>발신자</th>
                         <th>등록일</th>
                     </tr>
-                    <tr class="hover text-xs" th:classappend="${note.readDate == null} ? 'underline text-black' : 'text-gray-400'" th:if="${!note.deleteReceiver}" th:each="note, loop : ${notes}" th:data-noteid="${note.id}" onclick="detailPage(this)">
+                    <tr class="hover text-xs" th:classappend="${note.readDate == null} ? 'underline text-black' : 'text-gray-400'" th:if="${!note.deleteReceiver}" th:each="note, loop : ${notes}">
                         <td><input type="checkbox" name="deleteId" th:value="${note.id}"></td>
-                        <td th:text="${notes.totalElements - (notes.number * notes.size) - loop.count + 1}"></td>
-                        <td class="truncate-text" th:text="${note.title}"></td>
-                        <td class="truncate-text" th:text="${note.sender.nickname}"></td>
-                        <td class="text-xs" th:text="${#temporals.format(note.createDate, 'YY-MM-dd')}"></td>
+                        <td th:text="${notes.totalElements - (notes.number * notes.size) - loop.count + 1}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
+                        <td class="truncate-text" th:text="${note.title}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
+                        <td class="truncate-text" th:text="${note.sender.nickname}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
+                        <td class="text-xs" th:text="${#temporals.format(note.createDate, 'YY-MM-dd')}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
                     </tr>
                 </table>
                 <a href="/note/send" class="btn btn-link">새 쪽지 보내기</a>

--- a/src/main/resources/templates/usr/note/sendList.html
+++ b/src/main/resources/templates/usr/note/sendList.html
@@ -16,12 +16,12 @@
                         <th>수신자</th>
                         <th>등록일</th>
                     </tr>
-                    <tr class="hover text-xs" th:if="${!note.deleteSender}" th:each="note, loop : ${notes}" th:data-noteid="${note.id}" onclick="detailPage(this)">
+                    <tr class="hover text-xs" th:if="${!note.deleteSender}" th:each="note, loop : ${notes}">
                         <td><input type="checkbox" name="deleteId" th:value="${note.id}"></td>
-                        <td th:text="${notes.totalElements - (notes.number * notes.size) - loop.count + 1}"></td>
-                        <td class="truncate-text" th:text="${note.title}"></td>
-                        <td class="truncate-text" th:text="${note.receiver.nickname}"></td>
-                        <td class="text-xs" th:text="${#temporals.format(note.createDate, 'YY-MM-dd')}"></td>
+                        <td th:text="${notes.totalElements - (notes.number * notes.size) - loop.count + 1}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
+                        <td class="truncate-text" th:text="${note.title}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
+                        <td class="truncate-text" th:text="${note.receiver.nickname}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
+                        <td class="text-xs" th:text="${#temporals.format(note.createDate, 'YY-MM-dd')}" th:data-noteid="${note.id}" onclick="detailPage(this)"></td>
                     </tr>
                 </table>
                 <a href="/note/send" class="btn btn-link">새 쪽지 보내기</a>


### PR DESCRIPTION
- 알림 구현을 위해서 Member 엔티티에 연관 관계 필드 추가
    - List<Note> sendList → mappedBy = “sender”
    - List<Note> receiveList → mappedBy = “receiver”
- 받은 쪽지함에 읽지 않은 쪽지가 있다면, 상단 navbar에 indicator 표시
- 받은 쪽지함에 읽지 않은 쪽지가 있다면, 마이페이지 메뉴에 span 표시
- 쪽지함에서 체크박스 선택 시 상세보기 페이지로 이동되던 버그 수정