### PR TITLE
refactor: 기기 체크 기능 리팩토링

### DIFF
--- a/src/main/java/com/twenty/inhub/base/initData/InitData.java
+++ b/src/main/java/com/twenty/inhub/base/initData/InitData.java
@@ -67,8 +67,8 @@ public class InitData {
             public void run(String... args) throws Exception {
 
                 //-- user 추가 --//
-                Member memberAdmin = memberService.create(new MemberJoinForm("admin", "1234", "", "ADMIN")).getData();
-                Member user1 = memberService.create(new MemberJoinForm("user1", "1234", "", "USER1")).getData();
+                Member memberAdmin = memberService.create(new MemberJoinForm("admin", "1234", "", "ADMIN"), "").getData();
+                Member user1 = memberService.create(new MemberJoinForm("user1", "1234", "", "USER1"), "").getData();
 
                 //-- 카테고리 init data 추가 --//
                 Category network = createCategory("네트워크");

--- a/src/main/java/com/twenty/inhub/base/initData/InitDataProd.java
+++ b/src/main/java/com/twenty/inhub/base/initData/InitDataProd.java
@@ -21,7 +21,7 @@ public class InitDataProd {
             @Override
             @Transactional
             public void run(String... args) throws Exception {
-                Member memberAdmin = memberService.create(new MemberJoinForm("admin", "1234", "", "ADMIN")).getData();
+                Member memberAdmin = memberService.create(new MemberJoinForm("admin", "1234", "", "ADMIN"), "").getData();
             }
         };
     }

--- a/src/main/java/com/twenty/inhub/base/interceptor/DeviceCheckInterceptor.java
+++ b/src/main/java/com/twenty/inhub/base/interceptor/DeviceCheckInterceptor.java
@@ -40,12 +40,7 @@ public class DeviceCheckInterceptor implements HandlerInterceptor {
 
             log.info("인터셉터 -> 로그인 상태({})", member);
 
-            String username = member.getUsername();
-            if(username.equals("admin") || username.equals("user1")) {
-                return true;
-            }
-
-            if(member.getProviderTypeCode().equals("GITHUB") && member.getEmail() == null) {
+            if(member.getEmail() == null || member.getEmail().isBlank()) {
                 return true;
             }
 

--- a/src/main/java/com/twenty/inhub/base/interceptor/DeviceCheckInterceptor.java
+++ b/src/main/java/com/twenty/inhub/base/interceptor/DeviceCheckInterceptor.java
@@ -4,6 +4,7 @@ import com.twenty.inhub.base.request.Rq;
 import com.twenty.inhub.base.security.CustomOAuth2User;
 import com.twenty.inhub.boundedContext.device.Device;
 import com.twenty.inhub.boundedContext.device.DeviceRepository;
+import com.twenty.inhub.boundedContext.device.DeviceService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,7 +24,7 @@ import java.util.List;
 public class DeviceCheckInterceptor implements HandlerInterceptor {
 
     private final MemberService memberService;
-    private final DeviceRepository deviceRepository;
+    private final DeviceService deviceService;
     private final Rq rq;
 
     @Override
@@ -44,7 +45,7 @@ public class DeviceCheckInterceptor implements HandlerInterceptor {
                 return true;
             }
 
-            List<Device> devices = deviceRepository.findByMemberUsername(member.getUsername());
+            List<Device> devices = deviceService.findByMemberUsername(member.getUsername());
 
             String userAgent = request.getHeader("User-Agent");
             log.info("현재 접속 기기 = {}", userAgent);

--- a/src/main/java/com/twenty/inhub/base/interceptor/DeviceCheckInterceptor.java
+++ b/src/main/java/com/twenty/inhub/base/interceptor/DeviceCheckInterceptor.java
@@ -41,7 +41,11 @@ public class DeviceCheckInterceptor implements HandlerInterceptor {
             log.info("인터셉터 -> 로그인 상태({})", member);
 
             String username = member.getUsername();
-            if(username.equals("admin") || username.equals("user1") || !member.getProviderTypeCode().equals("INHUB")) {
+            if(username.equals("admin") || username.equals("user1")) {
+                return true;
+            }
+
+            if(member.getProviderTypeCode().equals("GITHUB") && member.getEmail() == null) {
                 return true;
             }
 

--- a/src/main/java/com/twenty/inhub/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/twenty/inhub/base/security/CustomOAuth2UserService.java
@@ -37,7 +37,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String username = providerTypeCode + "__%s".formatted(oauthId);
 
-        Member member = memberService.whenSocialLogin(providerTypeCode, username, attributes.getPicture(), attributes.getNickname()).getData();
+        Member member = memberService.whenSocialLogin(providerTypeCode, username, attributes.getPicture(), attributes.getNickname(), attributes.getEmail()).getData();
 
         return new CustomOAuth2User(member.getId(), member.getUsername(), member.getPassword(), member.getGrantedAuthorities());
     }

--- a/src/main/java/com/twenty/inhub/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/twenty/inhub/base/security/CustomOAuth2UserService.java
@@ -1,7 +1,9 @@
 package com.twenty.inhub.base.security;
 
+import com.twenty.inhub.boundedContext.device.DeviceService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
 import com.twenty.inhub.boundedContext.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -22,6 +24,8 @@ import java.util.Map;
 @Slf4j
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberService memberService;
+    private final DeviceService deviceService;
+    private final HttpServletRequest request;
 
     // 소셜 로그인이 성공할 때 마다 이 함수가 실행된다.
     @Override
@@ -37,7 +41,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String username = providerTypeCode + "__%s".formatted(oauthId);
 
-        Member member = memberService.whenSocialLogin(providerTypeCode, username, attributes.getPicture(), attributes.getNickname(), attributes.getEmail()).getData();
+        String userAgent = request.getHeader("User-Agent");
+
+        Member member = memberService.whenSocialLogin(providerTypeCode, username, attributes.getPicture(), attributes.getNickname(), attributes.getEmail(), userAgent).getData();
 
         return new CustomOAuth2User(member.getId(), member.getUsername(), member.getPassword(), member.getGrantedAuthorities());
     }

--- a/src/main/java/com/twenty/inhub/base/security/OAuthAttributes.java
+++ b/src/main/java/com/twenty/inhub/base/security/OAuthAttributes.java
@@ -34,9 +34,12 @@ public class OAuthAttributes {
     }
 
     private static OAuthAttributes ofGoogle(Map<String, Object> attributes) {
+        log.info("구글 수집 정보 = {}", attributes);
+
         return OAuthAttributes.builder()
                 .nickname((String) attributes.get("sub"))
                 .picture((String) attributes.get("picture"))
+                .email((String) attributes.get("email"))
                 .build();
     }
 
@@ -56,6 +59,8 @@ public class OAuthAttributes {
     }
 
     private static OAuthAttributes ofGitHub(Map<String, Object> attributes) {
+        log.info("깃허브 수집 정보 = {}", attributes);
+
         return OAuthAttributes.builder()
                 .nickname((String) attributes.get("login"))
                 .picture((String) attributes.get("avatar_url"))

--- a/src/main/java/com/twenty/inhub/base/security/OAuthAttributes.java
+++ b/src/main/java/com/twenty/inhub/base/security/OAuthAttributes.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 
@@ -11,11 +12,13 @@ import java.util.Map;
 @Builder
 @AllArgsConstructor
 @ToString
+@Slf4j
 public class OAuthAttributes {
 
     private Map<String, Object> attributes;
     private String nickname;
     private String picture;
+    private String email;
 
     public static OAuthAttributes of(String registrationId, Map<String, Object> attributes){
         // 여기서 깃허브와 카카오, 구글 구분 (ofGitHub, ofKakao. ofGoogle)
@@ -43,9 +46,12 @@ public class OAuthAttributes {
         // kakao_account안에 또 profile이라는 JSON객체가 있다. (nickname, profile_image)
         Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
 
+        log.info("카카오 수집 정보 = {}", kakaoAccount);
+
         return OAuthAttributes.builder()
                 .nickname(attributes.get("id").toString())
                 .picture((String) kakaoProfile.get("profile_image_url"))
+                .email((String) kakaoAccount.get("email"))
                 .build();
     }
 

--- a/src/main/java/com/twenty/inhub/boundedContext/device/DeviceService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/device/DeviceService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -38,5 +40,9 @@ public class DeviceService {
         member.getDevices().add(saved);
 
         return RsData.of("S-1", "기기 인증 성공", saved);
+    }
+
+    public List<Device> findByMemberUsername(String username) {
+        return deviceRepository.findByMemberUsername(username);
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberController.java
@@ -170,6 +170,22 @@ public class MemberController {
     }
 
     @PreAuthorize("isAuthenticated()")
+    @GetMapping("/registration")
+    public String registrationForm() {
+        return "usr/member/registration";
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/registration")
+    public String registration(String email) {
+        log.info("보안 강화 이메일 등록 = {}", email);
+
+        RsData<Member> rsData = memberService.regEmail(rq.getMember(), email);
+
+        return rq.redirectWithMsg("/", rsData);
+    }
+
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/mypage")
     public String myPage(Model model) {
         int rank = memberService.getRanking(rq.getMember());

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberController.java
@@ -68,12 +68,14 @@ public class MemberController {
 
     @PreAuthorize("isAnonymous()")
     @PostMapping("/join")
-    public String join(@Valid MemberJoinForm form, BindingResult result) {
+    public String join(@Valid MemberJoinForm form, BindingResult result, HttpServletRequest request) {
         if(result.hasErrors()) {
             return rq.historyBack("올바른 입력 형식이 아닙니다.");
         }
 
-        RsData<Member> rsData = memberService.create(form);
+        String userAgent = request.getHeader("User-Agent");
+
+        RsData<Member> rsData = memberService.create(form, userAgent);
 
         log.info("회원가입 결과 메세지 = {}", rsData.getMsg());
         log.info("회원가입된 계정 정보 = {}", rsData.getData());

--- a/src/main/java/com/twenty/inhub/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/entity/Member.java
@@ -48,6 +48,7 @@ public class Member {
     private String password;
     @Setter
     private String nickname;
+    @Setter
     private String email;
     @Setter
     private String profileImg;

--- a/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
@@ -286,6 +286,13 @@ public class MemberService {
         return RsData.of("S-1", "비밀번호가 변경되었습니다.<br>새 비밀번호로 로그인 해주세요.");
     }
 
+    @Transactional
+    public RsData<Member> regEmail(Member member, String email) {
+        member.setEmail(email);
+
+        return RsData.of("S-1", "보안 강화를 위한 이메일 등록이 완료 되었습니다.", member);
+    }
+
     public Optional<Member> findById(Long id) {
         return memberRepository.findById(id);
     }

--- a/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.twenty.inhub.base.appConfig.S3Config;
 import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.device.Device;
+import com.twenty.inhub.boundedContext.device.DeviceService;
 import com.twenty.inhub.boundedContext.mail.service.MailService;
 import com.twenty.inhub.boundedContext.member.controller.form.MemberJoinForm;
 import com.twenty.inhub.boundedContext.member.controller.form.MemberUpdateForm;
@@ -41,6 +43,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
     private final MailService mailService;
+    private final DeviceService deviceService;
     private final AmazonS3 amazonS3;
     private final S3Config s3Config;
     @Value("${cloud.aws.s3.storage}")
@@ -49,17 +52,17 @@ public class MemberService {
     // 일반 회원가입(삭제 예정)
     @Transactional
     public RsData<Member> create(String username, String password) {
-        return create("INHUB", username, password, "", "", "");
+        return create("INHUB", username, password, "", "", "", "");
     }
 
     // 일반 회원가입
     @Transactional
-    public RsData<Member> create(MemberJoinForm form) {
-        return create("INHUB", form.getUsername(), form.getPassword(), null, form.getNickname(), form.getEmail());
+    public RsData<Member> create(MemberJoinForm form, String userAgent) {
+        return create("INHUB", form.getUsername(), form.getPassword(), null, form.getNickname(), form.getEmail(), userAgent);
     }
 
     // 내부 처리함수, 일반회원가입, 소셜로그인을 통한 회원가입(최초 로그인 시 한번만 발생)에서 이 함수를 사용함
-    private RsData<Member> create(String providerTypeCode, String username, String password, String profileImg, String nickname, String email) {
+    private RsData<Member> create(String providerTypeCode, String username, String password, String profileImg, String nickname, String email, String userAgent) {
         if (findByUsername(username).isPresent()) {
             return RsData.of("F-1", "해당 아이디(%s)는 이미 사용중입니다.".formatted(username));
         }
@@ -95,6 +98,8 @@ public class MemberService {
                 .profileImg(profileImg)
                 .build();
 
+        deviceService.addAuthenticationDevice(member, userAgent);
+
         memberRepository.save(member);
 
         return RsData.of("S-1", "회원가입이 완료되었습니다.", member);
@@ -102,7 +107,7 @@ public class MemberService {
 
     // 소셜 로그인(카카오, 구글, 네이버) 로그인이 될 때 마다 실행되는 함수
     @Transactional
-    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String profileImg, String nickname, String email) {
+    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String profileImg, String nickname, String email, String userAgent) {
         Optional<Member> opMember = findByUsername(username); // username 예시 : KAKAO__1312319038130912, NAVER__1230812300
 
         if (opMember.isPresent()) {
@@ -110,7 +115,7 @@ public class MemberService {
         }
 
         // 소셜 로그인를 통한 가입시 비번은 없다.
-        return create(providerTypeCode, username, "", profileImg, nickname, email); // 최초 로그인 시 딱 한번 실행
+        return create(providerTypeCode, username, "", profileImg, nickname, email, userAgent); // 최초 로그인 시 딱 한번 실행
     }
 
     @Transactional

--- a/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
@@ -290,6 +290,10 @@ public class MemberService {
     public RsData<Member> regEmail(Member member, String email) {
         member.setEmail(email);
 
+        if(member.getEmail().isBlank() || member.getEmail() == null) {
+            return RsData.of("F-1", "보안 강화를 위한 이메일 등록이 실패하였습니다.");
+        }
+
         return RsData.of("S-1", "보안 강화를 위한 이메일 등록이 완료 되었습니다.", member);
     }
 

--- a/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/service/MemberService.java
@@ -102,7 +102,7 @@ public class MemberService {
 
     // 소셜 로그인(카카오, 구글, 네이버) 로그인이 될 때 마다 실행되는 함수
     @Transactional
-    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String profileImg, String nickname) {
+    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String profileImg, String nickname, String email) {
         Optional<Member> opMember = findByUsername(username); // username 예시 : KAKAO__1312319038130912, NAVER__1230812300
 
         if (opMember.isPresent()) {
@@ -110,7 +110,7 @@ public class MemberService {
         }
 
         // 소셜 로그인를 통한 가입시 비번은 없다.
-        return create(providerTypeCode, username, "", profileImg, nickname, null); // 최초 로그인 시 딱 한번 실행
+        return create(providerTypeCode, username, "", profileImg, nickname, email); // 최초 로그인 시 딱 한번 실행
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,12 +25,13 @@ spring:
             client-authentication-method: POST
             clientId: ENC(b+fkQMzqlkGg8s2x3Zu+nHuISd2tlVBjzfuWYde22fUiUnfTXf2C2w5togefVw0k)
           google:
-            scope: profile
+            scope: profile, email
             client-name: Google
             redirect-uri: '${custom.site.baseUrl}/{action}/oauth2/code/{registrationId}'
             clientId: ENC(qbe5qvL4sOPf/Wugu4mMTtM4XY5O8Wp0B+S5FE2IbqPpRbxgkMSa9eb0b/NsbNY3NxFa93JOvOQReSZKxlMRHunjEhaDw8dY/FQVr8HE8YEeqvJxbe/NNA==)
             client-secret: ENC(syyok3nI4CUx8QcxwHjUpzP7yhakU0wrYmMDvMQV/eiUE7iY6AvMr7PnUNP12Ksr)
           github:
+            scope: email
             clientId: ENC(NYNzs6okzII64/4rbBQ6NN0nDj4Zc+SofwLeX/dMndA=)
             client-secret: ENC(tzLcF+J3nBHmE5wBUsR0lqHdrZ1ntjZfC5Mm7yzTKcV4LpAD5dKpwSxmVBurSpsMpag6T/I/p0Q=)
         provider:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       client:
         registration:
           kakao:
-            scope: profile_image
+            scope: profile_image, account_email
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: '${custom.site.baseUrl}/{action}/oauth2/code/{registrationId}'

--- a/src/main/resources/templates/usr/member/device/authentication.html
+++ b/src/main/resources/templates/usr/member/device/authentication.html
@@ -6,6 +6,9 @@
 
     <!-- 이곳에 로직을 구현해주시면 됩니다 -->
     <div class="p-10 flex flex-col gap-4">
+        <h1 class="text-xl font-bold">평소와 다른 기기(환경)에서 접속하셨습니다.</h1>
+        <h1 class="text-xl font-bold">이메일을 통한 본인 인증 후 서비스를 이용해주세요.</h1>
+        <br>
         <h1 class="text-xl font-bold">가입하신 이메일로 기기 인증코드가 발송되었습니다.</h1>
         <h1 class="text-xl font-bold">이메일을 확인해주세요.</h1>
     </div>

--- a/src/main/resources/templates/usr/member/mypage.html
+++ b/src/main/resources/templates/usr/member/mypage.html
@@ -68,10 +68,10 @@
                     <div class="mt-4">
                         <div>
                             <i class="fa-solid fa-user"></i>
-                            사용자
+                            연동 이메일
                         </div>
                         <div class="mt-2">
-                            <span class="badge badge-primary" th:text="${@rq.member.username}"></span>
+                            <span class="badge badge-primary" th:text="${@rq.member.email}"></span>
                         </div>
                     </div>
 

--- a/src/main/resources/templates/usr/member/mypage.html
+++ b/src/main/resources/templates/usr/member/mypage.html
@@ -21,7 +21,7 @@
                             <a class="badge ml-2" href="/member/profileUpdate">수정</a>
                         </div>
                         <div>
-                            <a th:if="${@rq.member.email == null}" class="badge badge-secondary">보안 강화하기</a>
+                            <a href="/member/registration" th:if="${@rq.member.email == null}" class="badge badge-secondary">보안 강화하기</a>
                         </div>
                     </h2>
 

--- a/src/main/resources/templates/usr/member/mypage.html
+++ b/src/main/resources/templates/usr/member/mypage.html
@@ -14,10 +14,15 @@
         <div class="flex flex-col gap-4">
             <div class="card bg-base-100 shadow-xl">
                 <div class="card-body">
-                    <h2 class="card-title">
-                        <i class="fa-solid fa-id-card"></i>
-                        내 정보
-                        <a class="badge" href="/member/profileUpdate">수정</a>
+                    <h2 class="card-title flex items-center justify-between">
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-id-card"></i>
+                            <span class="ml-2">내 정보</span>
+                            <a class="badge ml-2" href="/member/profileUpdate">수정</a>
+                        </div>
+                        <div>
+                            <a th:if="${@rq.member.email == null}" class="badge badge-secondary">보안 강화하기</a>
+                        </div>
                     </h2>
 
                     <div class="mt-4">

--- a/src/main/resources/templates/usr/member/registration.html
+++ b/src/main/resources/templates/usr/member/registration.html
@@ -87,7 +87,11 @@
     </script>
 
     <div class="max-w-2xl w-full px-4">
-        <h2 class="p-10 flex flex-col gap-4">보안 강화를 위해 이메일을 등록해주세요.</h2>
+        <div class="p-10 flex flex-col gap-4">
+            <h2>보안 강화를 위해 이메일을 등록해주세요.</h2>
+            <br>
+            <h2>다른 기기(환경)에서 접속 시, 이메일로 본인인증을 하기 위함입니다.</h2>
+        </div>
 
         <form th:action method="POST" class="p-10 flex flex-col gap-4" onsubmit="JoinForm__submit(this); return false;">
             <!-- 이메일 -->

--- a/src/main/resources/templates/usr/member/registration.html
+++ b/src/main/resources/templates/usr/member/registration.html
@@ -1,0 +1,115 @@
+<html layout:decorate="~{layout/layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta id="_csrf" name="_csrf" th:content="${_csrf.token}"/>
+    <!-- default header name is X-CSRF-TOKEN -->
+    <meta id="_csrf_header" name="_csrf_header" th:content="${_csrf.headerName}"/>
+    <title>이메일 등록</title>
+</head>
+
+<div layout:fragment="content" class="min-h-screen flex flex-col items-center gap-12">
+
+    <!-- 이곳에 로직을 구현해주시면 됩니다 -->
+    <script>
+        emailConfirmCheck = false;
+
+        function JoinForm__submit(form) {
+            // 인증번호 이(가) 올바른지 체크
+            if (!emailConfirmCheck) {
+                toastWarning('인증번호를 다시 확인해주세요.');
+                form.code.focus();
+                return;
+            }
+
+            form.submit(); // 폼 발송
+        }
+    </script>
+    <script>
+        var token = $("meta[name='_csrf']").attr("content");
+        var header = $("meta[name='_csrf_header']").attr("content");
+        $(function() {
+            var $email = $("#email");
+            var $checkEmail = $("#checkEmail"); // 인증번호 발송 버튼
+            var $emailConfirm = $("#emailConfirm"); // 인증번호 확인input
+            var $emailConfirmTxt = $("#emailConfirmTxt"); // 인증번호 확인 txt
+
+            // 이메일 인증번호
+            $checkEmail.click(function () {
+                $.ajax({
+                    type: "POST",
+                    url: "/member/login/mailConfirm",
+                    data: {
+                        "email": $email.val()
+                    },
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader(header, token); // CSRF 토큰을 헤더에 추가
+                    },
+                    success: function (data) {
+                        toastNotice('해당 이메일로 인증번호 발송이 완료되었습니다.<br>확인부탁드립니다.');
+                        console.log("data : " + data);
+                        $("#emailConfirm").prop("disabled", false);
+                        checkEmailConfirm(data, $emailConfirm, $emailConfirmTxt);
+                    },
+                    error: function() {
+                        toastWarning('인증번호 발송에 실패했습니다.<br>다시 시도해주세요.');
+                        console.log("Error: 유효하지 않은 이메일입니다.");
+                    }
+                })
+            })
+
+            // 이메일 인증번호 체크 함수
+            function checkEmailConfirm(data, $emailConfirm, $emailConfirmTxt) {
+                $emailConfirm.on("keyup", function () {
+                    if (data != $emailConfirm.val()) { //
+                        emailConfirmCheck = false;
+                        $emailConfirmTxt.html("<span id='emailConfirmCheck'>인증번호가 잘못되었습니다</span>")
+                        $("#emailConfirmCheck").css({
+                            "color": "#FA3E3E",
+                            "font-weight": "bold",
+                            "font-size": "10px"
+
+                        })
+                        //console.log("중복아이디");
+                    } else { // 아니면 중복아님
+                        emailConfirmCheck = true;
+                        $emailConfirmTxt.html("<span id='emailConfirmCheck'>인증번호 확인 완료</span>")
+
+                        $("#emailConfirmCheck").css({
+                            "color": "#0D6EFD",
+                            "font-weight": "bold",
+                            "font-size": "10px"
+
+                        })
+                    }
+                })
+            }
+        });
+    </script>
+
+    <div class="max-w-2xl w-full px-4">
+        <h2 class="p-10 flex flex-col gap-4">보안 강화를 위해 이메일을 등록해주세요.</h2>
+
+        <form th:action method="POST" class="p-10 flex flex-col gap-4" onsubmit="JoinForm__submit(this); return false;">
+            <!-- 이메일 -->
+            <div class="flex gap-2 items-center">
+                <input type="text" class="input input-bordered" name="email" id="email" placeholder="이메일을 입력해주세요.">
+                <button class="btn btn-accent btn-xs" type="button" id="checkEmail">인증하기</button>
+            </div>
+            <!-- 인증번호 -->
+            <div class="flex flex-col">
+                <input type="text" class="input input-bordered" name="code" id="emailConfirm" placeholder="인증번호는 8자리 입니다." disabled>
+                <label for="emailConfirm" id="emailConfirmTxt">
+                    <span id="emailConfirmCheck-before">인증번호를 입력해주세요.</span>
+                </label>
+            </div>
+            <div class="mb-1">
+                <input type="submit" value="가입완료" class="btn btn-block btn-primary">
+            </div>
+        </form>
+    </div>
+
+    <div class="mt-5"></div>
+    <div class="mt-5"></div>
+
+</div>
+</html>

--- a/src/test/java/com/twenty/inhub/boundedContext/member/service/MemberServiceTest.java
+++ b/src/test/java/com/twenty/inhub/boundedContext/member/service/MemberServiceTest.java
@@ -26,8 +26,8 @@ class MemberServiceTest {
     @Test
     @DisplayName("일반 회원가입")
     void t01() {
-        Member member1 = memberService.create(new MemberJoinForm("test1", "1234", "", "test1")).getData();
-        Member member2 = memberService.create(new MemberJoinForm("test2", "1234", "", "test2")).getData();
+        Member member1 = memberService.create(new MemberJoinForm("test1", "1234", "", "test1"), "").getData();
+        Member member2 = memberService.create(new MemberJoinForm("test2", "1234", "", "test2"), "").getData();
         int count = memberService.findAll().size();
 
         assertThat(member1.getUsername()).isEqualTo("test1");
@@ -52,9 +52,9 @@ class MemberServiceTest {
     @Test
     @DisplayName("포인트 기준 랭킹 조회")
     void t03() {
-        Member member1 = memberService.create(new MemberJoinForm("test1", "1234", "", "test1")).getData();
-        Member member2 = memberService.create(new MemberJoinForm("test2", "1234", "", "test2")).getData();
-        Member member3 = memberService.create(new MemberJoinForm("test3", "1234", "", "test3")).getData();
+        Member member1 = memberService.create(new MemberJoinForm("test1", "1234", "", "test1"), "").getData();
+        Member member2 = memberService.create(new MemberJoinForm("test2", "1234", "", "test2"), "").getData();
+        Member member3 = memberService.create(new MemberJoinForm("test3", "1234", "", "test3"), "").getData();
 
         memberService.increasePoint(member1, 50);
         memberService.increasePoint(member2, 10);
@@ -72,9 +72,9 @@ class MemberServiceTest {
     @Test
     @DisplayName("가입 시 사용한 이메일로 아이디 찾기")
     void t04() {
-        Member member1 = memberService.create(new MemberJoinForm("test1", "1234", "test@test.com", "test1")).getData();
-        Member member2 = memberService.create(new MemberJoinForm("test2", "1234", "fake@fake.com", "test2")).getData();
-        Member member3 = memberService.create(new MemberJoinForm("test3", "1234", "test@test.com", "test3")).getData();
+        Member member1 = memberService.create(new MemberJoinForm("test1", "1234", "test@test.com", "test1"), "").getData();
+        Member member2 = memberService.create(new MemberJoinForm("test2", "1234", "fake@fake.com", "test2"), "").getData();
+        Member member3 = memberService.create(new MemberJoinForm("test3", "1234", "test@test.com", "test3"), "'").getData();
 
         RsData<List<String>> myIds = memberService.findMyIds("test@test.com");
 

--- a/src/test/java/com/twenty/inhub/boundedContext/note/service/NoteServiceTest.java
+++ b/src/test/java/com/twenty/inhub/boundedContext/note/service/NoteServiceTest.java
@@ -89,10 +89,10 @@ class NoteServiceTest {
     }
 
     private Member member() {
-        return memberService.create(new MemberJoinForm("test1", "1234", "test1@test.com", "test1_nickname")).getData();
+        return memberService.create(new MemberJoinForm("test1", "1234", "test1@test.com", "test1_nickname"), "").getData();
     }
 
     private Member admin() {
-        return memberService.create(new MemberJoinForm("admin", "1234", "admin@test.com", "admin")).getData();
+        return memberService.create(new MemberJoinForm("admin", "1234", "admin@test.com", "admin"), "").getData();
     }
 }


### PR DESCRIPTION
- 인터셉터 로직 수정
    - 소셜 회원가입한 사용자도 기기 체크 가능하게 변경
        - 깃허브 사용자는 마이페이지에서 추가적인 보안 설정으로 기기 체크 활성화

      **이유**
        → 깃허브로 가입 시, 이메일을 필수로 등록하지 않는 경우도 있고 등록했어도 사용자가 깃허브 계정 설정에서 public으로 이메일을 제공한다는 옵션을 활성화 하지 않으면 이메일이 null로 설정되기 때문에 무조건 이메일을 가져올 수 있다는 확신이 없다.
        
        </aside>
        
- 회원가입 시, 자동으로 현재 기기(환경) 등록을 하기 위한 회원가입 관련 로직 수정