### PR TITLE
feat: Member Open API 구현

### DIFF
--- a/src/main/java/com/twenty/inhub/base/appConfig/CustomErrorAttributes.java
+++ b/src/main/java/com/twenty/inhub/base/appConfig/CustomErrorAttributes.java
@@ -1,0 +1,22 @@
+package com.twenty.inhub.base.appConfig;
+
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Map;
+
+@Component
+public class CustomErrorAttributes extends DefaultErrorAttributes {
+
+    @Override
+    public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
+        Map<String, Object> errorAttributes = super.getErrorAttributes(webRequest, options);
+        errorAttributes.put("resultCode", "F-1");
+        errorAttributes.remove("trace");
+        errorAttributes.remove("status");
+        errorAttributes.remove("error");
+        return errorAttributes;
+    }
+}

--- a/src/main/java/com/twenty/inhub/base/appConfig/CustomErrorAttributes.java
+++ b/src/main/java/com/twenty/inhub/base/appConfig/CustomErrorAttributes.java
@@ -13,7 +13,6 @@ public class CustomErrorAttributes extends DefaultErrorAttributes {
     @Override
     public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
         Map<String, Object> errorAttributes = super.getErrorAttributes(webRequest, options);
-        errorAttributes.put("resultCode", "F-1");
         errorAttributes.remove("trace");
         errorAttributes.remove("status");
         errorAttributes.remove("error");

--- a/src/main/java/com/twenty/inhub/boundedContext/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/chat/controller/ChatMessageController.java
@@ -10,6 +10,7 @@ import com.twenty.inhub.boundedContext.chat.response.SignalResponse;
 import com.twenty.inhub.boundedContext.chat.service.ChatMessageService;
 import com.twenty.inhub.boundedContext.chat.service.ChatRoomService;
 import com.twenty.inhub.boundedContext.member.entity.Member;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Scope;
@@ -32,6 +33,7 @@ import static com.twenty.inhub.boundedContext.chat.response.SignalType.NEW_MESSA
 
 @Slf4j
 @Controller
+@Hidden
 @RequiredArgsConstructor
 public class ChatMessageController {
 

--- a/src/main/java/com/twenty/inhub/boundedContext/mail/controller/MailController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/mail/controller/MailController.java
@@ -1,6 +1,7 @@
 package com.twenty.inhub.boundedContext.mail.controller;
 
 import com.twenty.inhub.boundedContext.mail.service.MailService;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Slf4j
 @Controller
+@Hidden
 @RequiredArgsConstructor
 public class MailController {
 

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
@@ -1,10 +1,21 @@
 package com.twenty.inhub.boundedContext.member.controller;
 
+import com.twenty.inhub.base.jwt.JwtProvider;
+import com.twenty.inhub.base.request.RsData;
+import com.twenty.inhub.boundedContext.member.controller.dto.MemberResponseDto;
+import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.member.exception.MemberError;
+import com.twenty.inhub.boundedContext.member.exception.MemberException;
+import com.twenty.inhub.boundedContext.member.service.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -12,4 +23,18 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "회원 관련 API", description = "회원과 관련된 data 를 얻을 수 있습니다.")
 @RequiredArgsConstructor
 public class MemberOpenApiController {
+
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
+
+    @GetMapping("/{id}")
+    public RsData<MemberResponseDto> findById(@PathVariable("id") Long id) {
+        Optional<Member> member = memberService.findById(id);
+
+        if(member.isEmpty()) {
+            throw new MemberException(MemberError.NOT_VALID_MEMBER_ID);
+        }
+
+        return RsData.of(new MemberResponseDto(member.get()));
+    }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
@@ -8,6 +8,7 @@ import com.twenty.inhub.boundedContext.member.exception.MemberError;
 import com.twenty.inhub.boundedContext.member.exception.MemberException;
 import com.twenty.inhub.boundedContext.member.service.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +29,15 @@ public class MemberOpenApiController {
     private final JwtProvider jwtProvider;
 
     @GetMapping("/{id}")
-    public RsData<MemberResponseDto> findById(@PathVariable("id") Long id) {
+    public RsData<MemberResponseDto> findById(@PathVariable("id") Long id, HttpServletRequest request) {
+        log.info("API - memberId = {}", id);
+
+        String accessToken = request.getHeader("Bearer");
+
+        if (!jwtProvider.verify(accessToken)) {
+            throw new MemberException(MemberError.NOT_VALID_ACCESS_TOKEN);
+        }
+
         Optional<Member> member = memberService.findById(id);
 
         if(member.isEmpty()) {

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -29,7 +31,7 @@ public class MemberOpenApiController {
     private final JwtProvider jwtProvider;
 
     @GetMapping("/{id}")
-    public RsData<MemberResponseDto> findById(@PathVariable("id") Long id, HttpServletRequest request) {
+    public MemberResponseDto findById(@PathVariable("id") Long id, HttpServletRequest request) {
         log.info("API - memberId = {}", id);
 
         String accessToken = request.getHeader("Bearer");
@@ -44,6 +46,23 @@ public class MemberOpenApiController {
             throw new MemberException(MemberError.NOT_VALID_MEMBER_ID);
         }
 
-        return RsData.of(new MemberResponseDto(member.get()));
+        return new MemberResponseDto(member.get());
+    }
+
+    @GetMapping
+    public List<MemberResponseDto> findAll(HttpServletRequest request) {
+        log.info("API - memberAll");
+
+        String accessToken = request.getHeader("Bearer");
+
+        if (!jwtProvider.verify(accessToken)) {
+            throw new MemberException(MemberError.NOT_VALID_ACCESS_TOKEN);
+        }
+
+        List<Member> members = memberService.findAll();
+
+        return members.stream()
+                .map(MemberResponseDto::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberOpenApiController.java
@@ -1,0 +1,15 @@
+package com.twenty.inhub.boundedContext.member.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/member")
+@Tag(name = "회원 관련 API", description = "회원과 관련된 data 를 얻을 수 있습니다.")
+@RequiredArgsConstructor
+public class MemberOpenApiController {
+}

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberRestController.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/MemberRestController.java
@@ -1,6 +1,7 @@
 package com.twenty.inhub.boundedContext.member.controller;
 
 import com.twenty.inhub.boundedContext.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import java.util.Map;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
+@Hidden
 @RequestMapping("/member")
 public class MemberRestController {
 

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/dto/MemberResponseDto.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/dto/MemberResponseDto.java
@@ -1,17 +1,22 @@
 package com.twenty.inhub.boundedContext.member.controller.dto;
 
 import com.twenty.inhub.boundedContext.member.entity.Member;
-import com.twenty.inhub.boundedContext.question.entity.Question;
 import lombok.Data;
 
 @Data
 public class MemberResponseDto {
 
     private Long id;
+    private String providerType;
     private String nickname;
+    private int point;
+    private String status;
 
     public MemberResponseDto(Member member) {
         this.id = member.getId();
+        this.providerType = member.getProviderTypeCode();
         this.nickname = member.getNickname();
+        this.point = member.getPoint();
+        this.status = member.getStatus().toString();
     }
 }

--- a/src/main/java/com/twenty/inhub/boundedContext/member/controller/dto/MemberResponseDto.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/controller/dto/MemberResponseDto.java
@@ -1,0 +1,17 @@
+package com.twenty.inhub.boundedContext.member.controller.dto;
+
+import com.twenty.inhub.boundedContext.member.entity.Member;
+import com.twenty.inhub.boundedContext.question.entity.Question;
+import lombok.Data;
+
+@Data
+public class MemberResponseDto {
+
+    private Long id;
+    private String nickname;
+
+    public MemberResponseDto(Member member) {
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+    }
+}

--- a/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberError.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberError.java
@@ -1,0 +1,15 @@
+package com.twenty.inhub.boundedContext.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberError {
+    NOT_VALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 ID 입니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberError.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberError.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MemberError {
-    NOT_VALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 ID 입니다.")
+    NOT_VALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 ID 입니다."),
+    NOT_VALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰 입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberError.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberError.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MemberError {
-    NOT_VALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 ID 입니다."),
-    NOT_VALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰 입니다.")
+    //-- 이곳에 추가하고 싶은 ErrorCode 를 선언해주세요. --//
+    NOT_VALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰 입니다."),
+    NOT_VALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 ID 입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberException.java
+++ b/src/main/java/com/twenty/inhub/boundedContext/member/exception/MemberException.java
@@ -1,0 +1,14 @@
+package com.twenty.inhub.boundedContext.member.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException {
+
+    private final MemberError errorCode;
+
+    public MemberException(MemberError errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
## 📍MemerResponseDto.java

- 제공되는 회원 정보 목록
    - id, providerType, nickname, point, status

## 📍MemberOpenApiController.java

### “/api/member” → 전체 회원 데이터

- List<MemberResponseDto> findAll()

### “/api/member/{id}” → 단일 회원 데이터

- MemberResponseDto findById(Long id)
<hr>

### **Open API 응답할 때, 성공이 아닌 경우에 반환할 Custom Exception 클래스 개발**

### ❗ 구현 방법

- {도메인명}Exception.java → ex) MemberException.java
    - 상세 구현 방법은 MemberException.java 참조
- {도메인명}Error.java → ex) MemberError.java
    - 상세 구현 방법은 MemberError.java 참조

### **CustomErrorAttributes.java**

- API 호출 실패 시 반환되는 JSON 데이터에 원하지 않은 정보 제거해주는 설정
    
    ### **삭제한 정보 목록**
    
    - trace → 엄청 세세한 오류 스택 정보 출력이 되는데 지저분하다 생각해서 제거함
    - status → 따로 상태 값을 지정해주지 않으면 500 에러로 나와서, 상태 값을 지정하는 방법도 있지만 불필요하다 생각해서 제거함
    - error → status의 메세지를 출력해주는데, 이 값 또한 500 에러의 메세지라 같은 이유로 제거함